### PR TITLE
Add Luftdaten statistics proxy functionality

### DIFF
--- a/app/pages/tests.py
+++ b/app/pages/tests.py
@@ -1,7 +1,11 @@
-from django.test import SimpleTestCase
-from django.urls import reverse, resolve
+from unittest.mock import Mock, patch
 
-from .views import HomePageView
+from django.core.cache import cache
+from django.test import SimpleTestCase
+from django.urls import resolve, reverse
+from requests.exceptions import RequestException
+
+from .views import HomePageView, LUFTDATEN_STATISTICS_REQUEST_TIMEOUT
 
 
 class HomepageTests(SimpleTestCase):
@@ -25,3 +29,64 @@ class HomepageTests(SimpleTestCase):
     def test_homepage_url_resolves_homepageview(self):
         view = resolve("/")
         self.assertEqual(view.func.__name__, HomePageView.as_view().__name__)
+
+
+class LuftdatenStatisticsProxyTests(SimpleTestCase):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+
+    @patch("pages.views.requests.get")
+    def test_proxy_returns_upstream_json(self, mock_get):
+        mock_resp = Mock()
+        mock_resp.json.return_value = {
+            "active_stations": {"last_hour": 42, "last_24_hours": 100},
+        }
+        mock_resp.raise_for_status = Mock()
+        mock_get.return_value = mock_resp
+
+        response = self.client.get(reverse("luftdaten_statistics_proxy"))
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["active_stations"]["last_hour"], 42)
+        mock_get.assert_called_once()
+        self.assertEqual(
+            mock_get.call_args.kwargs["timeout"],
+            LUFTDATEN_STATISTICS_REQUEST_TIMEOUT,
+        )
+
+    @patch("pages.views.requests.get")
+    def test_proxy_uses_cache_second_request_skips_upstream(self, mock_get):
+        mock_resp = Mock()
+        mock_resp.json.return_value = {"active_stations": {"last_hour": 1}}
+        mock_resp.raise_for_status = Mock()
+        mock_get.return_value = mock_resp
+        url = reverse("luftdaten_statistics_proxy")
+
+        self.client.get(url)
+        self.client.get(url)
+
+        mock_get.assert_called_once()
+
+    @patch("pages.views.logger.warning")
+    @patch("pages.views.requests.get")
+    def test_proxy_returns_empty_active_stations_on_upstream_error(
+        self, mock_get, mock_warning
+    ):
+        mock_get.side_effect = RequestException("upstream error")
+
+        response = self.client.get(reverse("luftdaten_statistics_proxy"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"active_stations": {}})
+        mock_warning.assert_called_once()
+        fmt, err = mock_warning.call_args[0]
+        self.assertEqual(fmt, "Luftdaten statistics proxy failed: %s")
+        self.assertIn("upstream error", str(err))
+
+    def test_proxy_url_resolves(self):
+        self.assertEqual(
+            reverse("luftdaten_statistics_proxy"),
+            "/proxy/luftdaten-statistics/",
+        )

--- a/app/pages/urls.py
+++ b/app/pages/urls.py
@@ -1,8 +1,19 @@
 from django.urls import path
-from .views import DocumentationPageView, HelpPageView, HomePageView
+
+from .views import (
+    DocumentationPageView,
+    HelpPageView,
+    HomePageView,
+    LuftdatenStatisticsProxyView,
+)
 
 urlpatterns = [
     path("documentation", DocumentationPageView.as_view(), name="documentation"),
     path("help", HelpPageView.as_view(), name="help"),
+    path(
+        "proxy/luftdaten-statistics/",
+        LuftdatenStatisticsProxyView.as_view(),
+        name="luftdaten_statistics_proxy",
+    ),
     path("", HomePageView.as_view(), name="home"),
 ]

--- a/app/pages/views.py
+++ b/app/pages/views.py
@@ -1,6 +1,20 @@
+import logging
+
+import requests
+from django.core.cache import cache
+from django.http import JsonResponse
+from django.views import View
 from django.views.generic import TemplateView
+from requests.exceptions import RequestException
 
 from main.settings import API_URL
+
+logger = logging.getLogger(__name__)
+
+# Successful /statistics JSON is cached to limit load on api.luftdaten.at (browser polls via home page).
+LUFTDATEN_STATISTICS_CACHE_TIMEOUT = 3600  # 1 hour
+# Upstream can be slow on staging; (connect, read) in seconds.
+LUFTDATEN_STATISTICS_REQUEST_TIMEOUT = (15, 60)
 
 
 class HelpPageView(TemplateView):
@@ -29,3 +43,26 @@ class DocumentationPageView(TemplateView):
         context = super().get_context_data(**kwargs)
         context['host'] = self.request.get_host()
         return context
+
+
+class LuftdatenStatisticsProxyView(View):
+    """Same-origin JSON proxy for api.luftdaten.at /statistics (avoids browser CORS / redirect limits)."""
+
+    cache_key = "luftdaten_statistics_proxy:payload"
+
+    def get(self, request, *args, **kwargs):
+        cache_key = f"{self.cache_key}:{API_URL}"
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return JsonResponse(cached)
+
+        url = f"{API_URL}/statistics"
+        try:
+            response = requests.get(url, timeout=LUFTDATEN_STATISTICS_REQUEST_TIMEOUT)
+            response.raise_for_status()
+            data = response.json()
+            cache.set(cache_key, data, LUFTDATEN_STATISTICS_CACHE_TIMEOUT)
+            return JsonResponse(data)
+        except (RequestException, ValueError, TypeError) as e:
+            logger.warning("Luftdaten statistics proxy failed: %s", e)
+            return JsonResponse({"active_stations": {}})

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -143,7 +143,7 @@
         }
 
         async function fetchActiveStationsStats() {
-            var url = API_URL + "/statistics";
+            var url = "{% url 'luftdaten_statistics_proxy' %}";
             try {
                 var resp = await fetch(url);
                 if (!resp.ok) {


### PR DESCRIPTION
- Implemented LuftdatenStatisticsProxyView to serve as a same-origin JSON proxy for the Luftdaten API, caching responses to reduce load.
- Added unit tests for the proxy view, covering successful data retrieval, caching behavior, and error handling for upstream failures.
- Updated URLs to include a new path for the Luftdaten statistics proxy.
- Modified home page template to fetch active stations statistics from the new proxy endpoint.