### PR TITLE
Update dependencies in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,12 +5,12 @@ cffi==2.0.0
 charset-normalizer==3.4.1
 click==8.1.8
 crispy-bootstrap5==2024.10
-cryptography==46.0.5
+cryptography==46.0.6
 defusedxml==0.7.1
 dj-database-url==2.3.0
 dj-email-url==1.0.6
 Django==6.0.3
-django-allauth==65.14.0
+django-allauth==65.14.1
 django-auditlog==3.0.0
 django-cache-url==3.4.5
 django-crispy-forms==2.3
@@ -35,7 +35,7 @@ pillow==12.1.1
 pip-review==1.3.0
 psycopg2-binary==2.9.10
 pycparser==2.22
-PyJWT==2.10.1
+PyJWT==2.12.0
 pyproj==3.7.1
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
@@ -43,7 +43,7 @@ python3-openid==3.2.0
 pytz==2025.2
 PyYAML==6.0.2
 referencing==0.36.2
-requests==2.32.4
+requests==2.33.0
 requests-oauthlib==2.0.0
 rpds-py==0.22.3
 shapely==2.1.0


### PR DESCRIPTION
- Bump cryptography from 46.0.5 to 46.0.6
- Upgrade django-allauth from 65.14.0 to 65.14.1
- Update PyJWT from 2.10.1 to 2.12.0
- Increase requests from 2.32.4 to 2.33.0