### PR TITLE
Add CORS support and remove Luftdaten statistics proxy

### DIFF
--- a/app/main/settings.py
+++ b/app/main/settings.py
@@ -85,6 +85,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'drf_spectacular',
     'drf_spectacular_sidecar',
+    'corsheaders',
     'auditlog',
     # Local
     'accounts.apps.AccountsConfig',
@@ -105,6 +106,7 @@ if not TESTING:
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -121,6 +123,17 @@ if not TESTING:
     MIDDLEWARE.insert(MIDDLEWARE.index('django.middleware.common.CommonMiddleware') + 1, 'debug_toolbar.middleware.DebugToolbarMiddleware')
 
 ROOT_URLCONF = 'main.urls'
+
+# Cross-origin browser requests (e.g. dev frontends). Origins are scheme + host + port.
+CORS_ALLOWED_ORIGINS = [
+    "http://localhost",
+    "http://127.0.0.1",
+]
+if DEBUG:
+    CORS_ALLOWED_ORIGIN_REGEXES = [
+        r"^http://localhost(:\d+)?$",
+        r"^http://127\.0\.0\.1(:\d+)?$",
+    ]
 
 TEMPLATES = [
     {

--- a/app/pages/tests.py
+++ b/app/pages/tests.py
@@ -1,12 +1,8 @@
 import json
-from unittest.mock import Mock, patch
 
-from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.cache import cache
 from django.test import SimpleTestCase, TestCase
 from django.urls import resolve, reverse
-from requests.exceptions import RequestException
 
 from .models import FAQEntry
 from .views import DocumentationPageView, HelpPageView, HomePageView
@@ -33,67 +29,6 @@ class HomepageTests(SimpleTestCase):
     def test_homepage_url_resolves_homepageview(self):
         view = resolve("/")
         self.assertEqual(view.func.__name__, HomePageView.as_view().__name__)
-
-
-class LuftdatenStatisticsProxyTests(SimpleTestCase):
-    def setUp(self):
-        super().setUp()
-        cache.clear()
-
-    @patch("pages.views.requests.get")
-    def test_proxy_returns_upstream_json(self, mock_get):
-        mock_resp = Mock()
-        mock_resp.json.return_value = {
-            "active_stations": {"last_hour": 42, "last_24_hours": 100},
-        }
-        mock_resp.raise_for_status = Mock()
-        mock_get.return_value = mock_resp
-
-        response = self.client.get(reverse("luftdaten_statistics_proxy"))
-
-        self.assertEqual(response.status_code, 200)
-        data = response.json()
-        self.assertEqual(data["active_stations"]["last_hour"], 42)
-        mock_get.assert_called_once()
-        self.assertEqual(
-            mock_get.call_args.kwargs["timeout"],
-            settings.LUFTDATEN_API_REQUEST_TIMEOUT,
-        )
-
-    @patch("pages.views.requests.get")
-    def test_proxy_uses_cache_second_request_skips_upstream(self, mock_get):
-        mock_resp = Mock()
-        mock_resp.json.return_value = {"active_stations": {"last_hour": 1}}
-        mock_resp.raise_for_status = Mock()
-        mock_get.return_value = mock_resp
-        url = reverse("luftdaten_statistics_proxy")
-
-        self.client.get(url)
-        self.client.get(url)
-
-        mock_get.assert_called_once()
-
-    @patch("pages.views.logger.warning")
-    @patch("pages.views.requests.get")
-    def test_proxy_returns_empty_active_stations_on_upstream_error(
-        self, mock_get, mock_warning
-    ):
-        mock_get.side_effect = RequestException("upstream error")
-
-        response = self.client.get(reverse("luftdaten_statistics_proxy"))
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {"active_stations": {}})
-        mock_warning.assert_called_once()
-        fmt, err = mock_warning.call_args[0]
-        self.assertEqual(fmt, "Luftdaten statistics proxy failed: %s")
-        self.assertIn("upstream error", str(err))
-
-    def test_proxy_url_resolves(self):
-        self.assertEqual(
-            reverse("luftdaten_statistics_proxy"),
-            "/proxy/luftdaten-statistics/",
-        )
 
 
 class HelpPageTests(TestCase):

--- a/app/pages/urls.py
+++ b/app/pages/urls.py
@@ -7,7 +7,6 @@ from .views import (
     FAQReorderView,
     HelpPageView,
     HomePageView,
-    LuftdatenStatisticsProxyView,
 )
 
 urlpatterns = [
@@ -16,10 +15,5 @@ urlpatterns = [
     path("help/api/faq/", FAQCreateView.as_view(), name="faq_api_create"),
     path("help/api/faq/<int:pk>/", FAQEntryDetailView.as_view(), name="faq_api_detail"),
     path("help", HelpPageView.as_view(), name="help"),
-    path(
-        "proxy/luftdaten-statistics/",
-        LuftdatenStatisticsProxyView.as_view(),
-        name="luftdaten_statistics_proxy",
-    ),
     path("", HomePageView.as_view(), name="home"),
 ]

--- a/app/pages/views.py
+++ b/app/pages/views.py
@@ -1,9 +1,5 @@
 import json
-import logging
 
-import requests
-from django.conf import settings
-from django.core.cache import cache
 from django.db import transaction
 from django.db.models import Max
 from django.http import JsonResponse
@@ -11,14 +7,11 @@ from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext as _
 from django.views import View
 from django.views.generic import TemplateView
-from requests.exceptions import RequestException
 
 from main.settings import API_URL
 
 from .forms import FAQEntryStaffForm
 from .models import FAQEntry
-
-logger = logging.getLogger(__name__)
 
 
 def _faq_entry_json(entry):
@@ -190,28 +183,3 @@ class DocumentationPageView(TemplateView):
             },
         ]
         return context
-
-
-class LuftdatenStatisticsProxyView(View):
-    """Same-origin JSON proxy for api.luftdaten.at /statistics (avoids browser CORS / redirect limits)."""
-
-    cache_key = "luftdaten_statistics_proxy:payload"
-
-    def get(self, request, *args, **kwargs):
-        cache_key = f"{self.cache_key}:{API_URL}"
-        cached = cache.get(cache_key)
-        if cached is not None:
-            return JsonResponse(cached)
-
-        url = f"{API_URL}/statistics"
-        try:
-            response = requests.get(
-                url, timeout=settings.LUFTDATEN_API_REQUEST_TIMEOUT
-            )
-            response.raise_for_status()
-            data = response.json()
-            cache.set(cache_key, data, settings.LUFTDATEN_API_JSON_CACHE_TTL)
-            return JsonResponse(data)
-        except (RequestException, ValueError, TypeError) as e:
-            logger.warning("Luftdaten statistics proxy failed: %s", e)
-            return JsonResponse({"active_stations": {}})

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -56,7 +56,7 @@
         </div>
     </div>
 
-    <!-- Active Stations Statistics (values filled by fetchActiveStationsStats) -->
+    <!-- Active Stations Statistics (values filled by fetchActiveStationsStats)
     <div class="row mb-4 mt-4" id="active-stations-section">
         <div class="col-12">
             <h3 class="mb-3">{% trans "Active Stations" %}</h3>
@@ -101,7 +101,7 @@
                 </div>
             </div>
         </div>
-    </div>
+    </div> -->
 
     <script>
         const API_URL = "{{ API_URL }}"; 
@@ -196,14 +196,14 @@
         }
 
         async function fetchActiveStationsStats() {
-            var url = "{% url 'luftdaten_statistics_proxy' %}";
+            const statsUrl = `${API_URL}/statistics/`;
             try {
-                var resp = await fetch(url);
+                const resp = await fetch(statsUrl, { credentials: "omit" });
                 if (!resp.ok) {
                     console.error("Failed to fetch statistics, status:", resp.status);
                     return null;
                 }
-                var data = await resp.json();
+                const data = await resp.json();
                 return data.active_stations || {};
             } catch (err) {
                 console.error("Error fetching statistics:", err);

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ Django==6.0.4
 django-allauth==65.14.1
 django-auditlog==3.0.0
 django-cache-url==3.4.5
+django-cors-headers==4.7.0
 django-crispy-forms==2.3
 django-debug-toolbar==5.0.1
 django-log-viewer==1.1.8


### PR DESCRIPTION
- Added django-cors-headers to requirements and installed it in settings.
- Configured CORS_ALLOWED_ORIGINS for local development.
- Removed LuftdatenStatisticsProxyView and related tests and URLs.
- Updated home.html to fetch statistics directly from the API instead of the proxy.