### PR TITLE
Implement device API key synchronization with Luftdaten API

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ Development version:
 
 If you don't have a `.env` file yet, copy it from the template: `cp project.env .env`.
 
+**Luftdaten API (device / station API key sync):** When a superuser updates a device API key in the Datahub, the app calls `POST {API_URL}/station/apikey` on api.luftdaten.at so `stations.apikey` stays in sync. Configure:
+
+- `LUFTDATEN_ADMIN_API_KEY` — Bearer token; must match the **`ADMIN_API_KEY`** on api.luftdaten.at. If unset, saving a new API key from the Datahub will fail with a clear error (same as remote **503** when not configured).
+- `STATION_APIKEY_MIN_LENGTH` (optional, default **16**) — local minimum length before the request is sent; aligns with the remote API validation.
+
 **Shortcut:** run manage.py via the app container with:
 
     ./manage <command>

--- a/app/devices/forms.py
+++ b/app/devices/forms.py
@@ -1,4 +1,8 @@
 from django import forms
+from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
 from .models import Device
 
 
@@ -31,3 +35,16 @@ class DeviceApikeyForm(forms.ModelForm):
                 'autocomplete': 'off',
             }),
         }
+
+    def clean_api_key(self):
+        key = self.cleaned_data.get('api_key')
+        if key is None or not str(key).strip():
+            raise ValidationError(_('API key is required.'))
+        key = str(key).strip()
+        min_len = settings.STATION_APIKEY_MIN_LENGTH
+        if len(key) < min_len:
+            raise ValidationError(
+                _('The API key must be at least %(min)d characters long.'),
+                params={'min': min_len},
+            )
+        return key

--- a/app/devices/luftdaten_station_apikey.py
+++ b/app/devices/luftdaten_station_apikey.py
@@ -1,0 +1,99 @@
+import logging
+from typing import Any
+
+import requests
+from django.conf import settings
+from django.utils.translation import gettext as _
+
+logger = logging.getLogger(__name__)
+
+
+class StationApikeySyncError(Exception):
+    """Raised when syncing a device API key to api.luftdaten.at fails."""
+
+    def __init__(self, message: str, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _detail_from_response_body(data: Any) -> str | None:
+    if isinstance(data, dict):
+        detail = data.get("detail")
+        if isinstance(detail, str) and detail.strip():
+            return detail.strip()
+        if isinstance(detail, list) and detail:
+            first = detail[0]
+            if isinstance(first, dict):
+                msg = first.get("msg")
+                if isinstance(msg, str) and msg.strip():
+                    return msg.strip()
+    return None
+
+
+def sync_station_apikey(device_id: str, new_apikey: str) -> None:
+    """
+    POST {API_URL}/station/apikey with Bearer admin auth.
+    Raises StationApikeySyncError on configuration or HTTP/API errors.
+    """
+    admin_key = (settings.LUFTDATEN_ADMIN_API_KEY or "").strip()
+    if not admin_key:
+        raise StationApikeySyncError(
+            _("Luftdaten admin API key is not configured on this server."),
+            status_code=503,
+        )
+
+    url = f"{settings.API_URL.rstrip('/')}/station/apikey"
+    headers = {
+        "Authorization": f"Bearer {admin_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {"device": device_id, "new_apikey": new_apikey}
+
+    try:
+        resp = requests.post(
+            url,
+            json=payload,
+            headers=headers,
+            timeout=settings.LUFTDATEN_API_REQUEST_TIMEOUT,
+        )
+    except requests.RequestException as exc:
+        logger.warning(
+            "station apikey sync request failed: device=%s error=%s",
+            device_id,
+            exc,
+            exc_info=True,
+        )
+        raise StationApikeySyncError(
+            _("Could not reach api.luftdaten.at to update the API key. Try again later."),
+            status_code=None,
+        ) from exc
+
+    if resp.status_code == 200:
+        try:
+            body = resp.json()
+        except ValueError:
+            return
+        if isinstance(body, dict) and body.get("status") not in (None, "success"):
+            logger.warning(
+                "station apikey sync unexpected 200 body: device=%s body=%s",
+                device_id,
+                body,
+            )
+        return
+
+    try:
+        data = resp.json()
+    except ValueError:
+        data = None
+    detail = _detail_from_response_body(data)
+    msg = detail or resp.reason or _("API key update was rejected by api.luftdaten.at.")
+
+    log_fn = logger.error if resp.status_code >= 500 else logger.warning
+    log_fn(
+        "station apikey sync failed: device=%s status=%s detail=%s",
+        device_id,
+        resp.status_code,
+        detail or resp.text[:500],
+    )
+
+    raise StationApikeySyncError(str(msg), status_code=resp.status_code)

--- a/app/devices/test_station_apikey_sync.py
+++ b/app/devices/test_station_apikey_sync.py
@@ -1,0 +1,129 @@
+"""Tests for syncing device API keys to api.luftdaten.at (POST /station/apikey)."""
+
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from devices.luftdaten_station_apikey import StationApikeySyncError, sync_station_apikey
+from devices.models import Device
+from main.enums import LdProduct
+
+
+@override_settings(
+    LUFTDATEN_ADMIN_API_KEY='admin-bearer-token',
+    API_URL='https://api.test.example/v1',
+    LUFTDATEN_API_REQUEST_TIMEOUT=(3, 9),
+)
+class SyncStationApikeyHelperTests(TestCase):
+    """Unit tests for sync_station_apikey (mocked HTTP)."""
+
+    @patch('devices.luftdaten_station_apikey.requests.post')
+    def test_post_url_json_and_authorization_header(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {'status': 'success'}
+        mock_post.return_value = mock_resp
+
+        sync_station_apikey('device-abc-12345', 'newsecretkey12345')
+
+        mock_post.assert_called_once()
+        kwargs = mock_post.call_args.kwargs
+        self.assertEqual(
+            mock_post.call_args.args[0],
+            'https://api.test.example/v1/station/apikey',
+        )
+        self.assertEqual(
+            kwargs['json'],
+            {'device': 'device-abc-12345', 'new_apikey': 'newsecretkey12345'},
+        )
+        self.assertEqual(
+            kwargs['headers']['Authorization'],
+            'Bearer admin-bearer-token',
+        )
+        self.assertEqual(kwargs['headers']['Content-Type'], 'application/json')
+        self.assertEqual(kwargs['timeout'], (3, 9))
+
+    @patch('devices.luftdaten_station_apikey.requests.post')
+    def test_raises_when_admin_key_missing(self, mock_post):
+        with override_settings(LUFTDATEN_ADMIN_API_KEY=''):
+            with self.assertRaises(StationApikeySyncError) as ctx:
+                sync_station_apikey('d1', 'x' * 16)
+        self.assertEqual(ctx.exception.status_code, 503)
+        mock_post.assert_not_called()
+
+    @patch('devices.luftdaten_station_apikey.requests.post')
+    def test_raises_on_422_with_detail(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 422
+        mock_resp.reason = 'Unprocessable Entity'
+        mock_resp.text = '{"detail":"invalid key"}'
+        mock_resp.json.return_value = {'detail': 'invalid key'}
+        mock_post.return_value = mock_resp
+
+        with self.assertRaises(StationApikeySyncError) as ctx:
+            sync_station_apikey('dev', 'k' * 16)
+        self.assertEqual(ctx.exception.status_code, 422)
+        self.assertIn('invalid key', str(ctx.exception))
+
+
+@override_settings(
+    LUFTDATEN_ADMIN_API_KEY='admin-bearer-token',
+    API_URL='https://api.test.example/v1',
+)
+class DeviceApikeyUpdateViewSyncTests(TestCase):
+    """Integration-style tests: form submit triggers sync then DB update or rollback."""
+
+    def setUp(self):
+        self.superuser = get_user_model().objects.create_superuser(
+            username='admin',
+            email='admin@test.com',
+            password='testpass123',
+        )
+        self.device = Device.objects.create(
+            id='123456789012345',
+            model=LdProduct.AIR_STATION,
+            auto_number=1,
+            api_key='oldapikey12345678',
+        )
+        self.url = reverse('device-edit-apikey', kwargs={'pk': self.device.pk})
+
+    @patch('devices.luftdaten_station_apikey.requests.post')
+    def test_success_updates_device_api_key(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {'status': 'success'}
+        mock_post.return_value = mock_resp
+
+        new_key = 'newapikey123456789'
+        self.client.login(username='admin', password='testpass123')
+        response = self.client.post(self.url, {'api_key': new_key})
+
+        self.assertEqual(response.status_code, 302)
+        self.device.refresh_from_db()
+        self.assertEqual(self.device.api_key, new_key)
+        mock_post.assert_called_once()
+        body = mock_post.call_args.kwargs['json']
+        self.assertEqual(body['device'], self.device.pk)
+        self.assertEqual(body['new_apikey'], new_key)
+
+    @patch('devices.luftdaten_station_apikey.requests.post')
+    def test_remote_failure_leaves_api_key_unchanged(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 401
+        mock_resp.reason = 'Unauthorized'
+        mock_resp.text = ''
+        mock_resp.json.return_value = {'detail': 'Invalid token'}
+        mock_post.return_value = mock_resp
+
+        new_key = 'differentkey123456'
+        self.client.login(username='admin', password='testpass123')
+        response = self.client.post(self.url, {'api_key': new_key})
+
+        self.assertEqual(response.status_code, 200)
+        self.device.refresh_from_db()
+        self.assertEqual(self.device.api_key, 'oldapikey12345678')
+        form = response.context['form']
+        self.assertFalse(form.is_valid())
+        self.assertIn('api_key', form.errors)

--- a/app/devices/views.py
+++ b/app/devices/views.py
@@ -23,6 +23,7 @@ from django.contrib import messages
 from .models import Device, DeviceStatus, DeviceLogs, Measurement, Values
 from accounts.models import CustomUser
 from .forms import DeviceForm, DeviceNotesForm, DeviceApikeyForm
+from .luftdaten_station_apikey import StationApikeySyncError, sync_station_apikey
 from main.enums import SensorModel, Dimension, LdProduct
 from organizations.models import Organization
 from campaign.models import Room
@@ -708,6 +709,19 @@ class DeviceApikeyUpdateView(LoginRequiredMixin, UserPassesTestMixin, UpdateView
 
     def get_queryset(self):
         return Device.objects.all()
+
+    def form_valid(self, form):
+        new_key = form.cleaned_data.get('api_key')
+        if not new_key:
+            form.add_error('api_key', _('API key is required.'))
+            return self.form_invalid(form)
+        try:
+            sync_station_apikey(self.object.pk, new_key)
+        except StationApikeySyncError as exc:
+            form.add_error('api_key', str(exc))
+            messages.error(self.request, str(exc))
+            return self.form_invalid(form)
+        return super().form_valid(form)
 
 
 class DeviceLogLevelUpdateView(LoginRequiredMixin, UserPassesTestMixin, View):

--- a/app/main/settings.py
+++ b/app/main/settings.py
@@ -303,6 +303,11 @@ LUFTDATEN_API_REQUEST_TIMEOUT = (15, 60)
 # Shared TTL (seconds) for cached JSON from Luftdaten API (e.g. statistics proxy, station/all list).
 LUFTDATEN_API_JSON_CACHE_TTL = 3600
 
+# Bearer token for POST /v1/station/apikey (must match api.luftdaten.at ADMIN_API_KEY). Empty disables sync from Datahub.
+LUFTDATEN_ADMIN_API_KEY = env("LUFTDATEN_ADMIN_API_KEY", default="")
+# Minimum length for device/station API keys when syncing to api.luftdaten.at (matches STATION_APIKEY_MIN_LENGTH there).
+STATION_APIKEY_MIN_LENGTH = env.int("STATION_APIKEY_MIN_LENGTH", default=16)
+
 LOG_VIEWER_FILES = ['logs/log.log']
 #LOG_VIEWER_FILES_PATTERN = '*.log*'
 #LOG_VIEWER_FILES_DIR = 'logs/'

--- a/project.env
+++ b/project.env
@@ -11,3 +11,7 @@ EMAIL_HOST_USER=
 EMAIL_HOST_PASSWORD=
 EMAIL_PORT=
 EMAIL_USE_TLS=
+
+# Sync device API key to api.luftdaten.at POST /v1/station/apikey (Bearer = api.luftdaten.at ADMIN_API_KEY)
+# LUFTDATEN_ADMIN_API_KEY=
+# STATION_APIKEY_MIN_LENGTH=16


### PR DESCRIPTION
- Added functionality to sync device API keys to api.luftdaten.at when updated in the Datahub.
- Introduced `sync_station_apikey` function to handle the API call and error management.
- Updated `DeviceApikeyForm` to validate API key length based on configuration.
- Enhanced `DeviceApikeyUpdateView` to trigger synchronization and handle errors gracefully.
- Added tests for the synchronization process and validation logic.