### PR TITLE
Refactor station URL resolution and device name handling

### DIFF
--- a/app/accounts/dashboard_air.py
+++ b/app/accounts/dashboard_air.py
@@ -12,6 +12,7 @@ from django.utils.translation import gettext as _
 
 from main.enums import Dimension
 from main.pm25_colors import pm25_to_rgb
+from stations.station_url import resolve_station_from_pk
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +115,10 @@ def build_favorite_station_rows(favorites) -> List[dict]:
         r, g, b = pm25_to_rgb(pm)
         rows.append(
             {
-                "url": reverse("station-detail", kwargs={"pk": sid}),
+                "url": reverse(
+                    "station-detail",
+                    kwargs={"pk": resolve_station_from_pk(sid).detail_url_pk},
+                ),
                 "label": f"{_('Station')} {sid}",
                 "pm25": pm,
                 "r": r,

--- a/app/devices/migrations/0029_air_station_device_name_unpadded.py
+++ b/app/devices/migrations/0029_air_station_device_name_unpadded.py
@@ -1,0 +1,32 @@
+# Data migration: Air Station device_name without leading zeros in the number.
+
+from django.db import migrations
+
+
+def forwards(apps, schema_editor):
+    Device = apps.get_model("devices", "Device")
+    # LdProduct.AIR_STATION == 3
+    qs = Device.objects.filter(model=3).exclude(auto_number__isnull=True)
+    for d in qs.iterator():
+        new_name = f"Air Station {int(d.auto_number)}"
+        if d.device_name != new_name:
+            Device.objects.filter(pk=d.pk).update(device_name=new_name)
+
+
+def backwards(apps, schema_editor):
+    Device = apps.get_model("devices", "Device")
+    qs = Device.objects.filter(model=3).exclude(auto_number__isnull=True)
+    for d in qs.iterator():
+        old_name = f"Air Station {int(d.auto_number):04d}"
+        Device.objects.filter(pk=d.pk).update(device_name=old_name)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("devices", "0028_device_log_level"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, backwards),
+    ]

--- a/app/devices/models.py
+++ b/app/devices/models.py
@@ -51,7 +51,7 @@ class Device(models.Model):
         if self.auto_number:
             # assign name to update existing devices
             # TODO could be removed
-            self.device_name = f'{self.get_model_name()} {self.auto_number:04d}'
+            self._set_auto_device_name()
             super().save(*args, **kwargs)
             return
 
@@ -62,14 +62,21 @@ class Device(models.Model):
             counter.save()
 
             self.auto_number = counter.last_auto_number
-            '''
-            assigns a unique name for this device in this format: "{model name}{auto_number}"
-            for example "Air Cube 0001"
-            '''
-            self.device_name = f'{self.get_model_name()} {self.auto_number:04d}'
+            """
+            Name format: "{model} {n}". Air Station uses n without leading zeros; other models use 4 digits (e.g. Air Cube 0001).
+            """
+            self._set_auto_device_name()
         
         super().save(*args, **kwargs)
     
+    def _set_auto_device_name(self) -> None:
+        """Set device_name from model + auto_number (Air Station: no leading zeros in the number)."""
+        name = self.get_model_name()
+        if self.model == LdProduct.AIR_STATION:
+            self.device_name = f"{name} {int(self.auto_number)}"
+        else:
+            self.device_name = f"{name} {int(self.auto_number):04d}"
+
     def get_ble_id(self):
         # cuts of the 3 last characters that are use for board identification
         return self.id[:-3]

--- a/app/devices/tests.py
+++ b/app/devices/tests.py
@@ -61,7 +61,6 @@ class AirStationsOverviewTests(TestCase):
             id='123456789012345',
             model=LdProduct.AIR_STATION,
             auto_number=1,
-            device_name='Air Station 0001',
             firmware='1.0',
         )
         # Wrong model - should not appear
@@ -91,7 +90,6 @@ class AirStationsOverviewTests(TestCase):
             id='123456789012345',
             model=LdProduct.AIR_STATION,
             auto_number=1,
-            device_name='Test Station',
             firmware='2.0',
         )
         DeviceLogs.objects.create(

--- a/app/stations/station_url.py
+++ b/app/stations/station_url.py
@@ -1,0 +1,96 @@
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+from devices.models import Device
+from main.enums import LdProduct
+
+_AIR_AUTO_PK = re.compile(r"^\d{1,4}$")
+
+
+@dataclass
+class StationResolution:
+    """Resolve URL pk to canonical station_id and optional Air Station display metadata."""
+
+    canonical_id: str
+    device: Optional[Device]
+    is_air_station: bool
+    air_display_name: Optional[str]
+
+    @property
+    def detail_url_pk(self) -> str:
+        """Pk to use in station-detail and station-favorite-toggle URLs (short for air, no leading zeros)."""
+        if self.is_air_station and self.device is not None and self.device.auto_number is not None:
+            return str(int(self.device.auto_number))
+        return self.canonical_id
+
+
+def _air_friendly_name(device: Device) -> str:
+    if device.auto_number is not None:
+        return f"Air Station {int(device.auto_number)}"
+    if device.device_name:
+        return str(device.device_name)
+    return "Air Station"
+
+
+def resolve_station_from_pk(raw_pk: str) -> StationResolution:
+    raw = str(raw_pk).strip()
+    if not raw:
+        return StationResolution(
+            canonical_id=raw,
+            device=None,
+            is_air_station=False,
+            air_display_name=None,
+        )
+
+    dev = Device.objects.filter(pk=raw).first()
+    if dev is not None:
+        is_air = dev.model == LdProduct.AIR_STATION
+        return StationResolution(
+            canonical_id=dev.id,
+            device=dev,
+            is_air_station=is_air,
+            air_display_name=_air_friendly_name(dev) if is_air else None,
+        )
+
+    if _AIR_AUTO_PK.match(raw):
+        n = int(raw)
+        dev = (
+            Device.objects.filter(model=LdProduct.AIR_STATION, auto_number=n)
+            .order_by("id")
+            .first()
+        )
+        if dev is not None:
+            return StationResolution(
+                canonical_id=dev.id,
+                device=dev,
+                is_air_station=True,
+                air_display_name=_air_friendly_name(dev),
+            )
+
+    return StationResolution(
+        canonical_id=raw,
+        device=None,
+        is_air_station=False,
+        air_display_name=None,
+    )
+
+
+def air_station_url_pk_by_device_ids(
+    station_ids: list[str],
+) -> dict[str, str]:
+    """
+    Map full device id -> short auto_number string for public station URLs (no leading zeros).
+    """
+    if not station_ids:
+        return {}
+    sid_set = {str(s) for s in station_ids if s}
+    devices = (
+        Device.objects.filter(
+            model=LdProduct.AIR_STATION,
+            id__in=sid_set,
+        )
+        .exclude(auto_number__isnull=True)
+        .only("id", "auto_number")
+    )
+    return {str(d.id): str(int(d.auto_number)) for d in devices}

--- a/app/stations/templatetags/station_extras.py
+++ b/app/stations/templatetags/station_extras.py
@@ -1,0 +1,10 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def get_item(mapping, key):
+    if not mapping or key is None:
+        return None
+    return mapping.get(str(key))

--- a/app/stations/tests.py
+++ b/app/stations/tests.py
@@ -6,7 +6,8 @@ from django.core.cache import cache
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 
-from main.enums import Dimension, Order, OutputFormat
+from main.enums import Dimension, LdProduct, Order, OutputFormat
+from devices.models import Device
 from stations.models import FavoriteStation
 from stations.views import StationListView
 
@@ -753,3 +754,81 @@ class FavoriteStationTests(TestCase):
         r = self.client.post(url_toggle)
         self.assertEqual(r.status_code, 302)
         self.assertIn("login", r.url.lower())
+
+
+class AirStationUrlResolutionTests(TestCase):
+    def setUp(self):
+        self.air = Device.objects.create(
+            id="111111111111111",
+            model=LdProduct.AIR_STATION,
+            auto_number=7,
+            device_name="Air Station 7",
+        )
+
+    def test_detail_by_long_id_shows_friendly_name(self):
+        r = self.client.get(
+            reverse("station-detail", kwargs={"pk": "111111111111111"}),
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, "Air Station 7")
+        self.assertContains(
+            r, 'const STATION_ID = "111111111111111'
+        )  # API uses full canonical id
+
+    def test_detail_by_short_auto_number(self):
+        r = self.client.get(
+            reverse("station-detail", kwargs={"pk": "7"}),
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, "Air Station 7")
+        self.assertContains(
+            r, 'const STATION_ID = "111111111111111'
+        )
+
+    def test_five_plus_digit_string_not_treated_as_auto_number(self):
+        r = self.client.get(
+            reverse("station-detail", kwargs={"pk": "12345"}),
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, "12345")
+        self.assertContains(r, "Station")
+        self.assertNotContains(
+            r, "Air Station 7",
+        )
+        self.assertContains(r, 'const STATION_ID = "12345')
+
+    def test_bare_one_to_four_digits_without_air_stays_literal(self):
+        r = self.client.get(
+            reverse("station-detail", kwargs={"pk": "42"}),
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, "42")
+        self.assertContains(r, "Station")
+        self.assertContains(r, 'const STATION_ID = "42')
+
+    def test_favorite_toggle_short_stores_canonical_id_and_redirects_short(self):
+        User = get_user_model()
+        user = User.objects.create_user(
+            username="airstat",
+            email="airstat@test.com",
+            password="secret123",
+        )
+        self.client.login(username="airstat", password="secret123")
+        self.assertFalse(
+            FavoriteStation.objects.filter(
+                user=user, station_id="111111111111111"
+            ).exists()
+        )
+        r = self.client.post(
+            reverse("station-favorite-toggle", kwargs={"pk": "7"}),
+        )
+        self.assertTrue(
+            FavoriteStation.objects.filter(
+                user=user, station_id="111111111111111"
+            ).exists()
+        )
+        self.assertRedirects(
+            r,
+            reverse("station-detail", kwargs={"pk": "7"}),
+            fetch_redirect_response=False,
+        )

--- a/app/stations/views.py
+++ b/app/stations/views.py
@@ -13,10 +13,12 @@ from requests.exceptions import HTTPError, RequestException
 
 from main.enums import Dimension, Order, OutputFormat
 from .models import FavoriteStation
+from .station_url import air_station_url_pk_by_device_ids, resolve_station_from_pk
 
 
 def StationDetailView(request, pk):
-    station_id = str(pk).strip()
+    r = resolve_station_from_pk(str(pk))
+    station_id = r.canonical_id
     is_favorite = False
     if request.user.is_authenticated and station_id:
         is_favorite = FavoriteStation.objects.filter(
@@ -25,7 +27,13 @@ def StationDetailView(request, pk):
     return render(
         request,
         "stations/detail.html",
-        {"station_id": station_id, "is_favorite": is_favorite},
+        {
+            "station_id": station_id,
+            "station_detail_url_pk": r.detail_url_pk,
+            "is_favorite": is_favorite,
+            "is_air_station": r.is_air_station,
+            "air_display_name": r.air_display_name,
+        },
     )
 
 
@@ -33,7 +41,8 @@ class FavoriteStationToggleView(LoginRequiredMixin, View):
     """POST: add or remove this station from the user's favourites."""
 
     def post(self, request, pk):
-        station_id = str(pk).strip()[:64]
+        r = resolve_station_from_pk(str(pk))
+        station_id = r.canonical_id[:64] if r.canonical_id else ""
         if not station_id:
             messages.error(request, _("Invalid station."))
             return redirect("stations-list")
@@ -45,7 +54,9 @@ class FavoriteStationToggleView(LoginRequiredMixin, View):
         else:
             FavoriteStation.objects.create(user=request.user, station_id=station_id)
             messages.success(request, _("Added to favourite stations."))
-        return redirect(reverse("station-detail", kwargs={"pk": station_id}))
+        return redirect(
+            reverse("station-detail", kwargs={"pk": r.detail_url_pk})
+        )
 
 def StationListView(request):
     """
@@ -173,13 +184,22 @@ def StationListView(request):
     
     # Serialize to JSON for JavaScript
     all_stations_json = json.dumps(all_stations)
-    
+
+    air_lookup_ids: list[str] = [s["station_id"] for s in all_stations]
+    for _dim_key, dim_data in dimension_data.items():
+        for _section in ("top_stations", "lowest_stations"):
+            for row in dim_data.get(_section) or ():
+                if row and len(row) > 0 and row[0]:
+                    air_lookup_ids.append(str(row[0]))
+    air_url_pk = air_station_url_pk_by_device_ids(air_lookup_ids)
+
     context = {
         'dimension_data': dimension_data,
         'error': error_message,
         'active_stations': active_stations,
         'all_stations': all_stations,
         'all_stations_json': all_stations_json,
+        'air_station_url_pk': air_url_pk,
     }
 
     return render(request, 'stations/list.html', context)

--- a/app/templates/stations/detail.html
+++ b/app/templates/stations/detail.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load static %}
 
-{% block title %}{{ station_id }}{% endblock title %}
+{% block title %}{% if is_air_station and air_display_name %}{{ air_display_name }}{% else %}{{ station_id }}{% endif %}{% endblock title %}
 
 {% block styles %}
 <!-- Leaflet CSS -->
@@ -18,7 +18,11 @@
 {% block content %}
 <div class="row">
   <div class="col-lg-12">
+    {% if is_air_station and air_display_name %}
+    <h2 class="mt-5"><span id="station-id">{{ air_display_name }}</span></h2>
+    {% else %}
     <h2 class="mt-5">{% trans "Station" %} <span id="station-id">{{ station_id }}</span></h2>
+    {% endif %}
     
   </div>
 </div>
@@ -102,7 +106,7 @@
       <div class="card-body">
         <h5 class="card-title">{% trans "Station Information" %}</h5>
         {% if user.is_authenticated %}
-        <form method="post" action="{% url 'station-favorite-toggle' station_id %}" class="mb-3">
+        <form method="post" action="{% url 'station-favorite-toggle' station_detail_url_pk %}" class="mb-3">
           {% csrf_token %}
           {% if is_favorite %}
           <button type="submit" class="btn btn-outline-danger btn-sm">
@@ -178,7 +182,9 @@
 <!-- JavaScript-Code zur Initialisierung der Karte und Diagramme -->
 <script>
 const API_URL = "{{ API_URL }}";
-const STATION_ID = "{{ station_id }}";
+const STATION_ID = "{{ station_id|escapejs }}";
+const IS_AIR_STATION = {% if is_air_station %}true{% else %}false{% endif %};
+const AIR_STATION_MAP_LABEL = `{% if air_display_name %}{{ air_display_name|escapejs }}{% endif %}`;
 
 // Initialize map with default view (will be updated when data loads)
 var map = L.map('map').setView([48.2082, 16.3738], 13); // Default to Vienna
@@ -460,11 +466,13 @@ async function loadStationData() {
     const geometry = feature.geometry || {};
     const coordinates = geometry.coordinates || [];
     
+    if (!IS_AIR_STATION) {
     // Update station ID display in header
     document.getElementById('station-id').textContent = properties.device || STATION_ID;
     
     // Update sidebar station information
     document.getElementById('station-id-display').textContent = properties.device || STATION_ID;
+    }
     
     if (properties.time) {
       const timeDisplay = document.getElementById('station-time-display');
@@ -489,8 +497,11 @@ async function loadStationData() {
       if (marker) {
         map.removeLayer(marker);
       }
+      const popupLabel = (IS_AIR_STATION && AIR_STATION_MAP_LABEL)
+        ? AIR_STATION_MAP_LABEL
+        : ('Station ' + (properties.device || STATION_ID));
       marker = L.marker(stationCoordinates).addTo(map)
-        .bindPopup('Station ' + (properties.device || STATION_ID))
+        .bindPopup(popupLabel)
         .openPopup();
     }
     

--- a/app/templates/stations/list.html
+++ b/app/templates/stations/list.html
@@ -1,6 +1,7 @@
 {% extends "_base.html" %}
 {% load i18n %}
 {% load static %}
+{% load station_extras %}
 
 {% block title %}{% trans "All Stations" %}{% endblock title %}
 
@@ -266,7 +267,7 @@
                                 {% for station in dimension_data.pm1.top_stations %}
                                     <li class="list-group-item px-0">
                                         <div class="d-flex justify-content-between align-items-center">
-                    <a href="{% url 'station-detail' station.0 %}" class="station-link">
+                    <a href="{% url 'station-detail' air_station_url_pk|get_item:station.0|default:station.0 %}" class="station-link">
                         Station {{ station.0 }}
                     </a>
                                             <span class="badge rounded-pill">{{ station.3 }} µg/m³</span>
@@ -285,7 +286,7 @@
                                 {% for station in dimension_data.pm1.lowest_stations %}
                                     <li class="list-group-item px-0">
                                         <div class="d-flex justify-content-between align-items-center">
-                                            <a href="{% url 'station-detail' station.0 %}" class="station-link">
+                                            <a href="{% url 'station-detail' air_station_url_pk|get_item:station.0|default:station.0 %}" class="station-link">
                                                 Station {{ station.0 }}
                                             </a>
                                             <span class="badge rounded-pill">{{ station.3 }} µg/m³</span>
@@ -317,7 +318,7 @@
                             <ul class="list-group list-group-flush">
                                 {% for station in dimension_data.pm25.top_stations %}
                                     <li class="list-group-item d-flex justify-content-between align-items-center px-0">
-                                        <a href="{% url 'station-detail' station.0 %}" class="station-link">
+                                        <a href="{% url 'station-detail' air_station_url_pk|get_item:station.0|default:station.0 %}" class="station-link">
                                             Station {{ station.0 }}
                                         </a>
                                         <span class="badge rounded-pill">{{ station.3 }} µg/m³</span>
@@ -335,7 +336,7 @@
                                 {% for station in dimension_data.pm25.lowest_stations %}
                                     <li class="list-group-item px-0">
                                         <div class="d-flex justify-content-between align-items-center">
-                    <a href="{% url 'station-detail' station.0 %}" class="station-link">
+                    <a href="{% url 'station-detail' air_station_url_pk|get_item:station.0|default:station.0 %}" class="station-link">
                         Station {{ station.0 }}
                     </a>
                                             <span class="badge rounded-pill">{{ station.3 }} µg/m³</span>
@@ -367,7 +368,7 @@
                             <ul class="list-group list-group-flush">
                                 {% for station in dimension_data.pm10.top_stations %}
                                     <li class="list-group-item d-flex justify-content-between align-items-center px-0">
-                                        <a href="{% url 'station-detail' station.0 %}" class="station-link">
+                                        <a href="{% url 'station-detail' air_station_url_pk|get_item:station.0|default:station.0 %}" class="station-link">
                                             Station {{ station.0 }}
                                         </a>
                                         <span class="badge rounded-pill">{{ station.3 }} µg/m³</span>
@@ -385,7 +386,7 @@
                                 {% for station in dimension_data.pm10.lowest_stations %}
                                     <li class="list-group-item px-0">
                                         <div class="d-flex justify-content-between align-items-center">
-                                            <a href="{% url 'station-detail' station.0 %}" class="station-link">
+                                            <a href="{% url 'station-detail' air_station_url_pk|get_item:station.0|default:station.0 %}" class="station-link">
                                                 Station {{ station.0 }}
                                             </a>
                                             <span class="badge rounded-pill">{{ station.3 }} µg/m³</span>
@@ -435,7 +436,16 @@
     </div>
 </div>
 
+{{ air_station_url_pk|json_script:"air-station-url-pk" }}
 <script>
+    const airStationUrlPk = JSON.parse(
+        document.getElementById('air-station-url-pk').textContent
+    );
+    function stationDetailHref(stationId) {
+        const sid = String(stationId);
+        const shortPk = airStationUrlPk && airStationUrlPk[sid];
+        return '/stations/' + encodeURIComponent(shortPk || sid) + '/';
+    }
     // Color value map from home page
     const colorStepsPM1 = [
         [0,    [80, 240, 230],  "{% trans 'Good' %}"],
@@ -784,7 +794,7 @@
                             <button class="close-btn" onclick="d3.select('.station-popup').style('display', 'none')">&times;</button>
                             <h4>Station ${d.station_id}</h4>
                             <p><strong>Last Active:</strong> ${lastActiveText}</p>
-                            <a href="/stations/${d.station_id}">View Details</a>
+                            <a href="${stationDetailHref(d.station_id)}">View Details</a>
                         `)
                         .style('left', (x + 10) + 'px')
                         .style('top', (y - 10) + 'px')
@@ -877,7 +887,7 @@
                                     <button class="close-btn" onclick="d3.select('.station-popup').style('display', 'none')">&times;</button>
                                     <h4>Station ${d.station_id}</h4>
                                     <p><strong>Last Active:</strong> ${lastActiveText}</p>
-                                    <a href="/stations/${d.station_id}">View Details</a>
+                                    <a href="${stationDetailHref(d.station_id)}">View Details</a>
                                 `)
                                 .style('left', (x + 10) + 'px')
                                 .style('top', (y - 10) + 'px')


### PR DESCRIPTION
- Introduced `resolve_station_from_pk` function to resolve station IDs and improve URL handling for Air Stations.
- Updated `Device` model to set device names without leading zeros for Air Stations.
- Added migration to update existing device names in the database.
- Enhanced views and templates to utilize the new resolution logic, ensuring correct display of Air Station names and URLs.
- Added tests for the new URL resolution logic and updated existing tests to reflect changes.