### PR TITLE
Update device naming convention and station URL resolution

### DIFF
--- a/app/devices/migrations/0030_air_station_display_name_station_prefix.py
+++ b/app/devices/migrations/0030_air_station_display_name_station_prefix.py
@@ -1,0 +1,31 @@
+# Device display name: "Station {n}" instead of "Air Station {n}" for product Air Station (model=3).
+
+from django.db import migrations
+
+
+def forwards(apps, schema_editor):
+    Device = apps.get_model("devices", "Device")
+    qs = Device.objects.filter(model=3).exclude(auto_number__isnull=True)
+    for d in qs.iterator():
+        new_name = f"Station {int(d.auto_number)}"
+        if d.device_name != new_name:
+            Device.objects.filter(pk=d.pk).update(device_name=new_name)
+
+
+def backwards(apps, schema_editor):
+    Device = apps.get_model("devices", "Device")
+    qs = Device.objects.filter(model=3).exclude(auto_number__isnull=True)
+    for d in qs.iterator():
+        old_name = f"Air Station {int(d.auto_number)}"
+        Device.objects.filter(pk=d.pk).update(device_name=old_name)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("devices", "0029_air_station_device_name_unpadded"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, backwards),
+    ]

--- a/app/devices/models.py
+++ b/app/devices/models.py
@@ -63,19 +63,18 @@ class Device(models.Model):
 
             self.auto_number = counter.last_auto_number
             """
-            Name format: "{model} {n}". Air Station uses n without leading zeros; other models use 4 digits (e.g. Air Cube 0001).
+            Name format: "Station {n}" for Air Station (n unpadded), else "{model} {n:04d}" (e.g. Air Cube 0001).
             """
             self._set_auto_device_name()
         
         super().save(*args, **kwargs)
     
     def _set_auto_device_name(self) -> None:
-        """Set device_name from model + auto_number (Air Station: no leading zeros in the number)."""
-        name = self.get_model_name()
+        """Set device_name from model + auto_number (Air Station: "Station {n}" without leading zeros in n)."""
         if self.model == LdProduct.AIR_STATION:
-            self.device_name = f"{name} {int(self.auto_number)}"
+            self.device_name = f"Station {int(self.auto_number)}"
         else:
-            self.device_name = f"{name} {int(self.auto_number):04d}"
+            self.device_name = f"{self.get_model_name()} {int(self.auto_number):04d}"
 
     def get_ble_id(self):
         # cuts of the 3 last characters that are use for board identification

--- a/app/stations/station_url.py
+++ b/app/stations/station_url.py
@@ -10,7 +10,7 @@ _AIR_AUTO_PK = re.compile(r"^\d{1,4}$")
 
 @dataclass
 class StationResolution:
-    """Resolve URL pk to canonical station_id and optional Air Station display metadata."""
+    """Resolve URL pk to canonical station_id and optional Air (product) display metadata."""
 
     canonical_id: str
     device: Optional[Device]
@@ -27,10 +27,10 @@ class StationResolution:
 
 def _air_friendly_name(device: Device) -> str:
     if device.auto_number is not None:
-        return f"Air Station {int(device.auto_number)}"
+        return f"Station {int(device.auto_number)}"
     if device.device_name:
         return str(device.device_name)
-    return "Air Station"
+    return "Station"
 
 
 def resolve_station_from_pk(raw_pk: str) -> StationResolution:

--- a/app/stations/tests.py
+++ b/app/stations/tests.py
@@ -762,7 +762,7 @@ class AirStationUrlResolutionTests(TestCase):
             id="111111111111111",
             model=LdProduct.AIR_STATION,
             auto_number=7,
-            device_name="Air Station 7",
+            device_name="Station 7",
         )
 
     def test_detail_by_long_id_shows_friendly_name(self):
@@ -770,7 +770,7 @@ class AirStationUrlResolutionTests(TestCase):
             reverse("station-detail", kwargs={"pk": "111111111111111"}),
         )
         self.assertEqual(r.status_code, 200)
-        self.assertContains(r, "Air Station 7")
+        self.assertContains(r, "Station 7")
         self.assertContains(
             r, 'const STATION_ID = "111111111111111'
         )  # API uses full canonical id
@@ -780,7 +780,7 @@ class AirStationUrlResolutionTests(TestCase):
             reverse("station-detail", kwargs={"pk": "7"}),
         )
         self.assertEqual(r.status_code, 200)
-        self.assertContains(r, "Air Station 7")
+        self.assertContains(r, "Station 7")
         self.assertContains(
             r, 'const STATION_ID = "111111111111111'
         )
@@ -793,7 +793,7 @@ class AirStationUrlResolutionTests(TestCase):
         self.assertContains(r, "12345")
         self.assertContains(r, "Station")
         self.assertNotContains(
-            r, "Air Station 7",
+            r, "Station 7",
         )
         self.assertContains(r, 'const STATION_ID = "12345')
 


### PR DESCRIPTION
- Changed device naming format for Air Stations to "Station {n}" without leading zeros.
- Updated related functions and comments to reflect the new naming convention.
- Adjusted tests to ensure consistency with the updated naming format.