### PR TITLE
Implement city administration features for Luftdaten API

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ Development version:
 
 If you don't have a `.env` file yet, copy it from the template: `cp project.env .env`.
 
-**Luftdaten API (device / station API key sync):** When a superuser updates a device API key in the Datahub, the app calls `POST {API_URL}/station/apikey` on api.luftdaten.at so `stations.apikey` stays in sync. Configure:
+**Luftdaten API (device / station API key sync):** When a superuser updates a device API key in the Datahub, the app calls `POST {API_URL}/station/apikey` on api.luftdaten.at so `stations.apikey` stays in sync. Superusers can also adjust municipality coordinates from **Municipalities (API registry)** using `POST {API_URL}/city/admin` ([Admin Update City](https://api.luftdaten.at/docs#/city/admin_update_city_city_admin_post)). Both features use the same env var:
 
-- `LUFTDATEN_ADMIN_API_KEY` — Bearer token; must match the **`ADMIN_API_KEY`** on api.luftdaten.at. If unset, saving a new API key from the Datahub will fail with a clear error (same as remote **503** when not configured).
+- `LUFTDATEN_ADMIN_API_KEY` — Bearer token; must match the **`ADMIN_API_KEY`** on api.luftdaten.at. If unset, saving a new API key from the Datahub will fail with a clear error (same as remote **503** when not configured), and municipality location edits stay disabled.
 - `STATION_APIKEY_MIN_LENGTH` (optional, default **16**) — local minimum length before the request is sent; aligns with the remote API validation.
 
 **Shortcut:** run manage.py via the app container with:

--- a/app/main/settings.py
+++ b/app/main/settings.py
@@ -303,7 +303,8 @@ LUFTDATEN_API_REQUEST_TIMEOUT = (15, 60)
 # Shared TTL (seconds) for cached JSON from Luftdaten API (e.g. statistics proxy, station/all list).
 LUFTDATEN_API_JSON_CACHE_TTL = 3600
 
-# Bearer token for POST /v1/station/apikey (must match api.luftdaten.at ADMIN_API_KEY). Empty disables sync from Datahub.
+# Bearer token for POST /v1/station/apikey and POST /v1/city/admin (must match api.luftdaten.at ADMIN_API_KEY).
+# Empty disables device API key sync and municipality location updates from the Datahub.
 LUFTDATEN_ADMIN_API_KEY = env("LUFTDATEN_ADMIN_API_KEY", default="")
 # Minimum length for device/station API keys when syncing to api.luftdaten.at (matches STATION_APIKEY_MIN_LENGTH there).
 STATION_APIKEY_MIN_LENGTH = env.int("STATION_APIKEY_MIN_LENGTH", default=16)

--- a/app/municipalities/luftdaten_city_admin.py
+++ b/app/municipalities/luftdaten_city_admin.py
@@ -1,0 +1,121 @@
+import logging
+from typing import Any
+
+import requests
+from django.conf import settings
+from django.utils.translation import gettext as _
+
+logger = logging.getLogger(__name__)
+
+# api.luftdaten.at /city/all uses countries.slug; POST /city/admin expects ISO 3166 alpha-2/3.
+COUNTRY_SLUG_TO_ISO = {
+    "osterreich": "AT",
+}
+
+
+class CityAdminUpdateError(Exception):
+    """Raised when updating a city via api.luftdaten.at POST /city/admin fails."""
+
+    def __init__(self, message: str, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def country_code_for_country_slug(country_slug: str) -> str:
+    slug = (country_slug or "").strip().lower()
+    if not slug:
+        raise CityAdminUpdateError(_("Unknown country for this city (empty slug)."))
+    code = COUNTRY_SLUG_TO_ISO.get(slug)
+    if not code:
+        raise CityAdminUpdateError(
+            _("No ISO country code mapping for country slug “%(slug)s”. Add it in municipalities.luftdaten_city_admin.")
+            % {"slug": slug}
+        )
+    return code
+
+
+def _detail_from_response_body(data: Any) -> str | None:
+    if isinstance(data, dict):
+        detail = data.get("detail")
+        if isinstance(detail, str) and detail.strip():
+            return detail.strip()
+        if isinstance(detail, list) and detail:
+            first = detail[0]
+            if isinstance(first, dict):
+                msg = first.get("msg")
+                if isinstance(msg, str) and msg.strip():
+                    return msg.strip()
+    return None
+
+
+def update_city_admin(
+    *,
+    slug: str,
+    name: str,
+    tz: str,
+    lat: float,
+    lon: float,
+    country_code: str,
+) -> None:
+    """
+    POST {API_URL}/city/admin with Bearer admin auth (CityAdminSet schema).
+    """
+    admin_key = (settings.LUFTDATEN_ADMIN_API_KEY or "").strip()
+    if not admin_key:
+        raise CityAdminUpdateError(
+            _("Luftdaten admin API key is not configured on this server."),
+            status_code=503,
+        )
+
+    url = f"{settings.API_URL.rstrip('/')}/city/admin"
+    headers = {
+        "Authorization": f"Bearer {admin_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "slug": slug,
+        "name": name,
+        "tz": tz,
+        "lat": lat,
+        "lon": lon,
+        "country_code": country_code,
+    }
+
+    try:
+        resp = requests.post(
+            url,
+            json=payload,
+            headers=headers,
+            timeout=settings.LUFTDATEN_API_REQUEST_TIMEOUT,
+        )
+    except requests.RequestException as exc:
+        logger.warning(
+            "city admin update request failed: slug=%s error=%s",
+            slug,
+            exc,
+            exc_info=True,
+        )
+        raise CityAdminUpdateError(
+            _("Could not reach api.luftdaten.at to update the city. Try again later."),
+            status_code=None,
+        ) from exc
+
+    if resp.status_code == 200:
+        return
+
+    try:
+        data = resp.json()
+    except ValueError:
+        data = None
+    detail = _detail_from_response_body(data)
+    msg = detail or resp.reason or _("City update was rejected by api.luftdaten.at.")
+
+    log_fn = logger.error if resp.status_code >= 500 else logger.warning
+    log_fn(
+        "city admin update failed: slug=%s status=%s detail=%s",
+        slug,
+        resp.status_code,
+        detail or (resp.text[:500] if resp.text else None),
+    )
+
+    raise CityAdminUpdateError(str(msg), status_code=resp.status_code)

--- a/app/municipalities/tests.py
+++ b/app/municipalities/tests.py
@@ -1,10 +1,16 @@
 from unittest.mock import Mock, patch
 
 from django.contrib.auth import get_user_model
-from django.test import TestCase
-from django.urls import reverse
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from django.urls import resolve, reverse
 
 from municipalities.models import FavoriteMunicipality
+from municipalities.views import (
+    CITY_ALL_CACHE_KEY,
+    MunicipalitiesApiOverviewView,
+    MunicipalityAdminLocationUpdateView,
+)
 
 
 class FavoriteMunicipalityTests(TestCase):
@@ -106,3 +112,212 @@ class FavoriteMunicipalityTests(TestCase):
         r2 = self.client.get("/cities/wien/", follow=False)
         self.assertEqual(r2.status_code, 301)
         self.assertIn("/municipalities/wien", r2["Location"])
+
+
+class MunicipalitiesApiOverviewTests(TestCase):
+    """Superuser-only overview of /city/all from api.luftdaten.at."""
+
+    def setUp(self):
+        cache.clear()
+        self.url = reverse("municipalities-admin-overview")
+        User = get_user_model()
+        self.superuser = User.objects.create_superuser(
+            username="admin",
+            email="admin@test.com",
+            password="testpass123",
+        )
+        self.regular_user = User.objects.create_user(
+            username="user",
+            email="user@test.com",
+            password="testpass123",
+        )
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_url_resolves_to_correct_view(self):
+        match = resolve("/municipalities/admin/overview/")
+        self.assertEqual(
+            match.func.__name__,
+            MunicipalitiesApiOverviewView.as_view().__name__,
+        )
+
+    def test_unauthenticated_user_redirected_to_login(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("login", response.url)
+
+    def test_regular_user_gets_403(self):
+        self.client.login(username="user", password="testpass123")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 403)
+
+    @patch("municipalities.views.requests.get")
+    def test_superuser_can_access_and_sees_city_from_api(self, mock_get):
+        mock_resp = Mock()
+        mock_resp.json.return_value = {
+            "cities": [
+                {
+                    "id": 99,
+                    "name": "Teststadt",
+                    "slug": "teststadt",
+                    "location": {"latitude": 48.2, "longitude": 16.3},
+                    "country": {"name": "Österreich", "slug": "osterreich"},
+                }
+            ]
+        }
+        mock_resp.raise_for_status = Mock()
+        mock_get.return_value = mock_resp
+
+        self.client.login(username="admin", password="testpass123")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "municipalities/admin_overview.html")
+        self.assertContains(response, "Teststadt")
+        self.assertContains(response, "teststadt")
+
+    @patch("municipalities.views.requests.get")
+    @override_settings(LUFTDATEN_ADMIN_API_KEY="admin-secret")
+    def test_overview_shows_edit_when_admin_key_set(self, mock_get):
+        mock_resp = Mock()
+        mock_resp.json.return_value = {
+            "cities": [
+                {
+                    "id": 1,
+                    "name": "Teststadt",
+                    "slug": "teststadt",
+                    "location": {"latitude": 48.2, "longitude": 16.3},
+                    "country": {"name": "Österreich", "slug": "osterreich"},
+                }
+            ]
+        }
+        mock_resp.raise_for_status = Mock()
+        mock_get.return_value = mock_resp
+
+        self.client.login(username="admin", password="testpass123")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Edit location")
+
+
+class MunicipalityAdminLocationUpdateTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.post_url = reverse("municipalities-admin-update-location")
+        User = get_user_model()
+        self.superuser = User.objects.create_superuser(
+            username="admin",
+            email="admin@test.com",
+            password="testpass123",
+        )
+        self.regular_user = User.objects.create_user(
+            username="user",
+            email="user@test.com",
+            password="testpass123",
+        )
+        self._registry_row = {
+            "id": 1,
+            "name": "Teststadt",
+            "slug": "teststadt",
+            "country_name": "Österreich",
+            "country_slug": "osterreich",
+            "latitude": 48.2,
+            "longitude": 16.3,
+            "country_filter": "osterreich",
+        }
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_resolve(self):
+        match = resolve("/municipalities/admin/update-location/")
+        self.assertEqual(
+            match.func.__name__,
+            MunicipalityAdminLocationUpdateView.as_view().__name__,
+        )
+
+    def test_regular_user_post_forbidden(self):
+        cache.set(CITY_ALL_CACHE_KEY, [self._registry_row])
+        self.client.login(username="user", password="testpass123")
+        r = self.client.post(
+            self.post_url,
+            {
+                "city_slug": "teststadt",
+                "latitude": "48.3",
+                "longitude": "16.4",
+            },
+        )
+        self.assertEqual(r.status_code, 403)
+
+    @override_settings(LUFTDATEN_ADMIN_API_KEY="")
+    def test_missing_admin_key_shows_error(self):
+        cache.set(CITY_ALL_CACHE_KEY, [self._registry_row])
+        self.client.login(username="admin", password="testpass123")
+        r = self.client.post(
+            self.post_url,
+            {
+                "city_slug": "teststadt",
+                "latitude": "48.3",
+                "longitude": "16.4",
+            },
+            follow=True,
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(
+            r, "Luftdaten admin API key is not configured on this server."
+        )
+
+    @patch("municipalities.luftdaten_city_admin.requests.post")
+    @patch("municipalities.views.requests.get")
+    @override_settings(LUFTDATEN_ADMIN_API_KEY="admin-secret")
+    def test_superuser_post_calls_city_admin_and_clears_cache(
+        self, mock_views_get, mock_admin_post
+    ):
+        cache.set(CITY_ALL_CACHE_KEY, [self._registry_row])
+
+        cur = Mock()
+        cur.json.return_value = {
+            "properties": {"timezone": "Europe/Vienna"},
+        }
+        cur.raise_for_status = Mock()
+
+        def views_get(url, **kwargs):
+            if "city/current" in url:
+                return cur
+            raise AssertionError("unexpected GET " + url)
+
+        mock_views_get.side_effect = views_get
+
+        post_resp = Mock()
+        post_resp.status_code = 200
+        post_resp.json.return_value = {}
+        mock_admin_post.return_value = post_resp
+
+        self.client.login(username="admin", password="testpass123")
+        r = self.client.post(
+            self.post_url,
+            {
+                "city_slug": "teststadt",
+                "latitude": "48.333",
+                "longitude": "16.444",
+            },
+        )
+        self.assertRedirects(
+            r,
+            reverse("municipalities-admin-overview"),
+            fetch_redirect_response=False,
+        )
+        self.assertIsNone(cache.get(CITY_ALL_CACHE_KEY))
+        mock_admin_post.assert_called_once()
+        call_kw = mock_admin_post.call_args.kwargs
+        self.assertIn("json", call_kw)
+        body = call_kw["json"]
+        self.assertEqual(body["slug"], "teststadt")
+        self.assertEqual(body["name"], "Teststadt")
+        self.assertEqual(body["tz"], "Europe/Vienna")
+        self.assertEqual(body["lat"], 48.333)
+        self.assertEqual(body["lon"], 16.444)
+        self.assertEqual(body["country_code"], "AT")
+        headers = call_kw.get("headers") or mock_admin_post.call_args[1].get("headers")
+        self.assertIn("Authorization", headers)
+        self.assertTrue(headers["Authorization"].startswith("Bearer "))

--- a/app/municipalities/urls.py
+++ b/app/municipalities/urls.py
@@ -2,12 +2,24 @@ from django.urls import path
 
 from .views import (
     FavoriteMunicipalityToggleView,
+    MunicipalitiesApiOverviewView,
+    MunicipalityAdminLocationUpdateView,
     municipality_detail_view,
     municipalities_list_view,
 )
 
 urlpatterns = [
     path("", municipalities_list_view, name="municipalities-list"),
+    path(
+        "admin/overview/",
+        MunicipalitiesApiOverviewView.as_view(),
+        name="municipalities-admin-overview",
+    ),
+    path(
+        "admin/update-location/",
+        MunicipalityAdminLocationUpdateView.as_view(),
+        name="municipalities-admin-update-location",
+    ),
     path(
         "<str:pk>/favorite/",
         FavoriteMunicipalityToggleView.as_view(),

--- a/app/municipalities/views.py
+++ b/app/municipalities/views.py
@@ -3,16 +3,83 @@ import json
 import requests
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.core.cache import cache
 from django.http import Http404, HttpResponsePermanentRedirect
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.views import View
+from django.views.generic import TemplateView
 
 from main.enums import Dimension
 
+from .luftdaten_city_admin import (
+    CityAdminUpdateError,
+    country_code_for_country_slug,
+    update_city_admin,
+)
 from .models import FavoriteMunicipality
+
+CITY_ALL_CACHE_KEY = "city_all_data"
+
+
+def load_city_registry_cities():
+    """Return (cities, error_message). Caches successful fetches."""
+    cities = cache.get(CITY_ALL_CACHE_KEY)
+    if cities is not None:
+        return cities, None
+    try:
+        response = requests.get(
+            f"{settings.API_URL}/city/all",
+            timeout=settings.LUFTDATEN_API_REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+        cities = _normalize_cities_from_api(response.json())
+        cache.set(
+            CITY_ALL_CACHE_KEY,
+            cities,
+            settings.LUFTDATEN_API_JSON_CACHE_TTL,
+        )
+        return cities, None
+    except (
+        requests.exceptions.RequestException,
+        ValueError,
+        TypeError,
+    ) as exc:
+        return [], str(exc)
+
+
+def _normalize_cities_from_api(payload):
+    """Turn /city/all JSON into rows for the admin overview template."""
+    raw = payload.get("cities", []) if isinstance(payload, dict) else []
+    cities = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        loc = item.get("location") or {}
+        if not isinstance(loc, dict):
+            loc = {}
+        country = item.get("country") or {}
+        if not isinstance(country, dict):
+            country = {}
+        country_slug = country.get("slug") or ""
+        cities.append(
+            {
+                "id": item.get("id"),
+                "name": item.get("name") or "",
+                "slug": item.get("slug") or "",
+                "country_name": country.get("name") or "",
+                "country_slug": country_slug,
+                "latitude": loc.get("latitude"),
+                "longitude": loc.get("longitude"),
+                "country_filter": country_slug,
+            }
+        )
+    cities.sort(
+        key=lambda c: ((c["name"] or c["slug"] or "").lower(), c["slug"] or "")
+    )
+    return cities
 
 
 def cities_legacy_redirect(request, remainder=None):
@@ -86,6 +153,118 @@ def municipality_detail_view(request, pk):
             "is_favorite": is_favorite,
         },
     )
+
+
+class MunicipalitiesApiOverviewView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
+    """Superuser overview of all cities from api.luftdaten.at /city/all."""
+
+    template_name = "municipalities/admin_overview.html"
+
+    def test_func(self):
+        return self.request.user.is_authenticated and self.request.user.is_superuser
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        cities, error = load_city_registry_cities()
+        context["cities"] = cities
+        context["city_registry_error"] = error
+        context["luftdaten_admin_configured"] = bool(
+            (settings.LUFTDATEN_ADMIN_API_KEY or "").strip()
+        )
+        return context
+
+
+class MunicipalityAdminLocationUpdateView(LoginRequiredMixin, UserPassesTestMixin, View):
+    """POST: update city lat/lon on api.luftdaten.at via /city/admin."""
+
+    http_method_names = ["post"]
+
+    def test_func(self):
+        return self.request.user.is_authenticated and self.request.user.is_superuser
+
+    def post(self, request):
+        if not (settings.LUFTDATEN_ADMIN_API_KEY or "").strip():
+            messages.error(
+                request,
+                _("Luftdaten admin API key is not configured on this server."),
+            )
+            return redirect("municipalities-admin-overview")
+
+        slug = (request.POST.get("city_slug") or "").strip()
+        if not slug:
+            messages.error(request, _("Missing city identifier."))
+            return redirect("municipalities-admin-overview")
+        try:
+            lat = float(request.POST.get("latitude", ""))
+            lon = float(request.POST.get("longitude", ""))
+        except ValueError:
+            messages.error(request, _("Invalid latitude or longitude."))
+            return redirect("municipalities-admin-overview")
+        if not (-90 <= lat <= 90 and -180 <= lon <= 180):
+            messages.error(request, _("Latitude and longitude are out of range."))
+            return redirect("municipalities-admin-overview")
+
+        cities, _reg_err = load_city_registry_cities()
+        city_row = next((c for c in cities if c.get("slug") == slug), None)
+        if city_row is None:
+            messages.error(request, _("City not found in registry."))
+            return redirect("municipalities-admin-overview")
+
+        name = (city_row.get("name") or "").strip()
+        if not name:
+            messages.error(request, _("City has no name in registry."))
+            return redirect("municipalities-admin-overview")
+
+        country_slug = city_row.get("country_slug") or ""
+        try:
+            country_code = country_code_for_country_slug(country_slug)
+        except CityAdminUpdateError as exc:
+            messages.error(request, str(exc))
+            return redirect("municipalities-admin-overview")
+
+        try:
+            cur_resp = requests.get(
+                f"{settings.API_URL}/city/current",
+                params={"city_slug": slug},
+                timeout=settings.LUFTDATEN_API_REQUEST_TIMEOUT,
+            )
+            cur_resp.raise_for_status()
+            feat = cur_resp.json()
+        except (requests.exceptions.RequestException, ValueError, TypeError) as exc:
+            messages.error(
+                request,
+                _("Could not load current city data: %(err)s") % {"err": str(exc)},
+            )
+            return redirect("municipalities-admin-overview")
+
+        props = feat.get("properties") if isinstance(feat, dict) else None
+        if not isinstance(props, dict):
+            props = {}
+        tz = (props.get("timezone") or "").strip()
+        if not tz:
+            messages.error(request, _("City has no timezone in API response."))
+            return redirect("municipalities-admin-overview")
+
+        try:
+            update_city_admin(
+                slug=slug,
+                name=name,
+                tz=tz,
+                lat=lat,
+                lon=lon,
+                country_code=country_code,
+            )
+        except CityAdminUpdateError as exc:
+            messages.error(request, str(exc))
+            return redirect("municipalities-admin-overview")
+
+        cache.delete(CITY_ALL_CACHE_KEY)
+        messages.success(
+            request,
+            _("Updated location for %(name)s on api.luftdaten.at.")
+            % {"name": name},
+        )
+        return redirect("municipalities-admin-overview")
 
 
 class FavoriteMunicipalityToggleView(LoginRequiredMixin, View):

--- a/app/templates/_base.html
+++ b/app/templates/_base.html
@@ -63,6 +63,7 @@
                                 <li><a class="dropdown-item disabled" href="">Admin</a></li>
                                 <li><a class="dropdown-item" href="{% url 'devices-list' %}">{% trans "Devices" %}</a></li>
                                 <li><a class="dropdown-item" href="{% url 'air-stations-overview' %}">{% trans "Air Stations" %}</a></li>
+                                <li><a class="dropdown-item" href="{% url 'municipalities-admin-overview' %}">{% trans "Municipalities" %}</a></li>
                                 <li><a class="dropdown-item" href="{% url 'calibration' %}">{% trans "Calibration" %}</a></li>
                                 <li><a class="dropdown-item" href="{% url 'users-list' %}">{% trans "Users" %}</a></li>
                                 <li><a class="dropdown-item" href="/logs">{% trans "Logs" %}</a></li>

--- a/app/templates/municipalities/admin_overview.html
+++ b/app/templates/municipalities/admin_overview.html
@@ -1,0 +1,213 @@
+{% extends "_base.html" %}
+{% load i18n %}
+{% load static %}
+{% load humanize %}
+
+{% block title %}{% trans "Municipalities (API registry)" %}{% endblock title %}
+
+{% block styles %}
+<link rel="stylesheet" href="https://unpkg.com/bootstrap-table@1.21.2/dist/bootstrap-table.min.css"/>
+<script src="https://cdn.jsdelivr.net/npm/jquery/dist/jquery.min.js"></script>
+<script src="https://unpkg.com/bootstrap-table@1.21.2/dist/bootstrap-table.min.js"></script>
+{% endblock styles %}
+
+{% block content %}
+<div class="container mt-5">
+    {% if messages %}
+        {% for message in messages %}
+            <div class="alert alert-{{ message.tags }} alert-dismissible fade show" role="alert">{{ message }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="{% trans 'Close' %}"></button>
+            </div>
+        {% endfor %}
+    {% endif %}
+    <div class="d-flex flex-wrap justify-content-between align-items-center gap-3 mb-4">
+        <h2 class="mb-0">{% trans "Municipalities (API registry)" %}</h2>
+        {% if cities %}
+        <div class="ms-auto" style="min-width: 12rem; max-width: 22rem;">
+            <label for="municipalities-admin-table-search" class="visually-hidden">{% trans "Search" %}</label>
+            <input
+                type="search"
+                id="municipalities-admin-table-search"
+                class="form-control form-control-sm"
+                placeholder="{% trans 'Search' %}"
+                autocomplete="off"
+            >
+        </div>
+        {% endif %}
+    </div>
+
+    {% if city_registry_error %}
+    <div class="alert alert-warning" role="alert">
+        {% trans "Could not load city list from the API." %} {{ city_registry_error }}
+    </div>
+    {% endif %}
+
+    {% if not luftdaten_admin_configured %}
+    <div class="alert alert-info" role="alert">
+        {% trans "Set LUFTDATEN_ADMIN_API_KEY to enable updating coordinates via api.luftdaten.at POST /city/admin." %}
+    </div>
+    {% endif %}
+
+    {% if cities %}
+        <div
+            id="municipality-country-filters"
+            class="d-flex flex-wrap align-items-center gap-2 mb-3"
+            role="toolbar"
+            aria-label="{% trans 'Filter by country' %}"
+            data-label-all="{% trans 'All countries' %}"
+            data-label-na="{% trans 'N/A' %}"
+        >
+            <span class="text-muted small me-1">{% trans "Country" %}:</span>
+            <div class="d-flex flex-wrap gap-2" id="municipality-country-filter-buttons"></div>
+        </div>
+        <table
+            id="table"
+            data-toggle="table"
+            data-search="true"
+            data-search-selector="#municipalities-admin-table-search"
+            data-sortable="true"
+            data-pagination="true"
+            data-page-size="50"
+            data-page-list="[50, 100, 200]"
+            class="table">
+            <thead class="table-light">
+                <tr>
+                    <th data-field="id" data-sortable="true">{% trans "ID" %}</th>
+                    <th data-field="name" data-sortable="true">{% trans "Name" %}</th>
+                    <th data-field="slug" data-sortable="true">{% trans "Slug" %}</th>
+                    <th data-field="country" data-sortable="true">{% trans "Country" %}</th>
+                    <th data-field="latitude" data-sortable="true">{% trans "Latitude" %}</th>
+                    <th data-field="longitude" data-sortable="true">{% trans "Longitude" %}</th>
+                    <th data-field="actions" data-sortable="false">{% trans "Actions" %}</th>
+                    <th data-field="country_filter" data-visible="false" data-switchable="false">{% trans "Country filter" %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for city in cities %}
+                    <tr data-country-slug="{{ city.country_slug }}">
+                        <td>{{ city.id|default:"—" }}</td>
+                        <td>
+                            {% if city.slug %}
+                            <a href="{% url 'municipalities-detail' city.slug %}" class="btn btn-secondary btn-sm" title="{% trans 'View municipality' %}">{{ city.name|default:city.slug }}</a>
+                            {% else %}
+                            {{ city.name|default:"—" }}
+                            {% endif %}
+                        </td>
+                        <td><code class="small">{{ city.slug|default:"—" }}</code></td>
+                        <td>{{ city.country_name|default:"—" }}</td>
+                        <td>{% if city.latitude is not None %}{{ city.latitude }}{% else %}—{% endif %}</td>
+                        <td>{% if city.longitude is not None %}{{ city.longitude }}{% else %}—{% endif %}</td>
+                        <td>
+                            {% if city.slug and luftdaten_admin_configured %}
+                            <button
+                                type="button"
+                                class="btn btn-outline-primary btn-sm"
+                                data-bs-toggle="modal"
+                                data-bs-target="#editCityLocationModal"
+                                data-city-slug="{{ city.slug }}"
+                                data-city-name="{{ city.name|default:city.slug }}"
+                                data-latitude="{{ city.latitude|default_if_none:'' }}"
+                                data-longitude="{{ city.longitude|default_if_none:'' }}"
+                            >{% trans "Edit location" %}</button>
+                            {% elif city.slug %}
+                            <span class="text-muted small">{% trans "Admin API key required" %}</span>
+                            {% else %}
+                            —
+                            {% endif %}
+                        </td>
+                        <td>{{ city.country_filter }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% elif not city_registry_error %}
+        <div class="alert alert-warning" role="alert">
+            {% trans "No cities returned from the API." %}
+        </div>
+    {% endif %}
+
+    {% if cities and luftdaten_admin_configured %}
+    <div class="modal fade" id="editCityLocationModal" tabindex="-1" aria-labelledby="editCityLocationModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <form method="post" action="{% url 'municipalities-admin-update-location' %}">
+                    {% csrf_token %}
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="editCityLocationModalLabel">{% trans "Edit municipality location" %}</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans 'Close' %}"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p class="small text-muted mb-3" id="editCityLocationSubtitle"></p>
+                        <input type="hidden" name="city_slug" id="editCityLocationSlug" value="">
+                        <div class="mb-3">
+                            <label for="editCityLocationLat" class="form-label">{% trans "Latitude" %}</label>
+                            <input type="text" class="form-control" name="latitude" id="editCityLocationLat" inputmode="decimal" required autocomplete="off">
+                        </div>
+                        <div class="mb-3">
+                            <label for="editCityLocationLon" class="form-label">{% trans "Longitude" %}</label>
+                            <input type="text" class="form-control" name="longitude" id="editCityLocationLon" inputmode="decimal" required autocomplete="off">
+                        </div>
+                        <p class="small text-muted mb-0">{% trans "Uses api.luftdaten.at POST /city/admin (name and timezone are taken from the current registry and API; the city slug may change if the name ever changes on the API side)." %}</p>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Cancel" %}</button>
+                        <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+</div>
+{% endblock content %}
+
+{% block extra_js %}
+{% if cities %}
+<script>
+(function () {
+    if (typeof LuftdatenDatahub === "undefined" || !LuftdatenDatahub.initBootstrapTableFilterToolbars) {
+        return;
+    }
+    LuftdatenDatahub.initBootstrapTableFilterToolbars({
+        tableSelector: "#table",
+        filters: [
+            {
+                rowDataKey: "country_slug",
+                filterField: "country_filter",
+                toolbarSelector: "#municipality-country-filters",
+                buttonHostSelector: "#municipality-country-filter-buttons",
+                sort: "locale",
+            },
+        ],
+    });
+})();
+</script>
+{% endif %}
+{% if cities and luftdaten_admin_configured %}
+<script>
+(function () {
+    var modal = document.getElementById("editCityLocationModal");
+    if (!modal) {
+        return;
+    }
+    modal.addEventListener("show.bs.modal", function (event) {
+        var btn = event.relatedTarget;
+        if (!btn || !btn.getAttribute) {
+            return;
+        }
+        var slug = btn.getAttribute("data-city-slug") || "";
+        var name = btn.getAttribute("data-city-name") || "";
+        var lat = btn.getAttribute("data-latitude") || "";
+        var lon = btn.getAttribute("data-longitude") || "";
+        document.getElementById("editCityLocationSlug").value = slug;
+        document.getElementById("editCityLocationLat").value = lat;
+        document.getElementById("editCityLocationLon").value = lon;
+        var sub = document.getElementById("editCityLocationSubtitle");
+        if (sub) {
+            sub.textContent = name + " (" + slug + ")";
+        }
+    });
+})();
+</script>
+{% endif %}
+{% endblock extra_js %}


### PR DESCRIPTION
- Added a new view for superusers to manage city data via the Luftdaten API, including updating municipality coordinates.
- Introduced a dedicated URL for the municipalities admin overview and a form for updating city locations.
- Enhanced the README to document the new features and their configuration requirements.
- Implemented caching for city data to optimize API calls and improve performance.
- Added tests to ensure proper access control and functionality of the new city administration features.