### PR TITLE
Update package versions in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cffi==2.0.0
 charset-normalizer==3.4.1
 click==8.1.8
 crispy-bootstrap5==2024.10
-cryptography==46.0.6
+cryptography==46.0.7
 defusedxml==0.7.1
 dj-database-url==2.3.0
 dj-email-url==1.0.6
@@ -32,14 +32,14 @@ marshmallow==3.26.2
 numpy==2.2.2
 oauthlib==3.2.2
 packaging==24.2
-pillow==12.1.1
+pillow==12.2.0
 pip-review==1.3.0
 psycopg2-binary==2.9.10
 pycparser==2.22
 PyJWT==2.12.0
 pyproj==3.7.1
 python-dateutil==2.9.0.post0
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 python3-openid==3.2.0
 pytz==2025.2
 PyYAML==6.0.2


### PR DESCRIPTION
- Bumped cryptography from 46.0.6 to 46.0.7
- Updated pillow from 12.1.1 to 12.2.0
- Upgraded python-dotenv from 1.0.1 to 1.2.2