### PR TITLE
Add sensor scan parsing and update logic for DeviceStatus

### DIFF
--- a/app/api/tests/test_devices.py
+++ b/app/api/tests/test_devices.py
@@ -5,7 +5,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from api.models import MobilityMode
-from devices.models import Device, DeviceLogs
+from devices.models import Device, DeviceLogs, DeviceStatus
 from workshops.models import Workshop, Participant
 
 
@@ -114,6 +114,189 @@ class DeviceStatusEndpointTest(TestCase):
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def _status_payload(self, **device_overrides):
+        base = {
+            "time": "2025-01-07T12:00:00Z",
+            "device": self.device.id,
+            "firmware": "1.0",
+            "model": 1,
+            "apikey": "secret-key-123",
+            "battery": {"voltage": 3.7, "percentage": 80},
+        }
+        base.update(device_overrides)
+        return {"device": base, "status_list": []}
+
+    def test_sensor_scan_info_updates_sensor_list(self):
+        em_dash = "\u2014"
+        payload = self._status_payload()
+        payload["status_list"] = [
+            {
+                "time": "2025-01-07T12:00:00Z",
+                "level": 1,
+                "message": f"[INFO] Sensor scan: 2 connected {em_dash} 5, 26",
+            }
+        ]
+        response = self.client.post(
+            reverse("api:v1:device-status"),
+            data=payload,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        st = DeviceStatus.objects.filter(device=self.device).latest("time_received")
+        self.assertEqual(
+            st.sensor_list,
+            [
+                {"model_id": 5, "dimension_list": []},
+                {"model_id": 26, "dimension_list": []},
+            ],
+        )
+
+    def test_sensor_scan_without_info_bracket_updates_sensor_list(self):
+        payload = self._status_payload()
+        payload["status_list"] = [
+            {
+                "time": "2025-01-07T12:05:00Z",
+                "level": 1,
+                "message": "Sensor scan: 2 connected - 7, 8",
+            }
+        ]
+        response = self.client.post(
+            reverse("api:v1:device-status"),
+            data=payload,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        st = DeviceStatus.objects.filter(device=self.device).latest("time_received")
+        self.assertEqual(
+            st.sensor_list,
+            [
+                {"model_id": 7, "dimension_list": []},
+                {"model_id": 8, "dimension_list": []},
+            ],
+        )
+
+    def test_sensor_scan_non_info_level_does_not_update_sensor_list(self):
+        payload = self._status_payload(
+            sensor_list=[{"model_id": 1, "dimension_list": [2]}],
+        )
+        payload["status_list"] = [
+            {
+                "time": "2025-01-07T12:10:00Z",
+                "level": 0,
+                "message": "Sensor scan: 2 connected \u2014 99, 100",
+            }
+        ]
+        response = self.client.post(
+            reverse("api:v1:device-status"),
+            data=payload,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        st = DeviceStatus.objects.filter(device=self.device).latest("time_received")
+        self.assertEqual(st.sensor_list, [{"model_id": 1, "dimension_list": [2]}])
+
+    def test_sensor_scan_unrelated_info_leaves_sensor_list_none(self):
+        payload = self._status_payload()
+        payload["status_list"] = [
+            {
+                "time": "2025-01-07T12:15:00Z",
+                "level": 1,
+                "message": "Device idle",
+            }
+        ]
+        response = self.client.post(
+            reverse("api:v1:device-status"),
+            data=payload,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        st = DeviceStatus.objects.filter(device=self.device).latest("time_received")
+        self.assertIsNone(st.sensor_list)
+
+    def test_sensor_scan_preserves_dimension_list_when_model_id_overlap(self):
+        payload = self._status_payload(
+            sensor_list=[{"model_id": 5, "dimension_list": [2, 3, 5]}],
+        )
+        payload["status_list"] = [
+            {
+                "time": "2025-01-07T12:20:00Z",
+                "level": 1,
+                "message": "[INFO] Sensor scan: 2 connected \u2014 5, 26",
+            }
+        ]
+        response = self.client.post(
+            reverse("api:v1:device-status"),
+            data=payload,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        st = DeviceStatus.objects.filter(device=self.device).latest("time_received")
+        self.assertEqual(
+            st.sensor_list,
+            [
+                {"model_id": 5, "dimension_list": [2, 3, 5]},
+                {"model_id": 26, "dimension_list": []},
+            ],
+        )
+
+    def test_sensor_scan_last_matching_line_wins(self):
+        payload = self._status_payload()
+        payload["status_list"] = [
+            {
+                "time": "2025-01-07T11:00:00Z",
+                "level": 1,
+                "message": "Sensor scan: 1 connected \u2014 1",
+            },
+            {
+                "time": "2025-01-07T12:00:00Z",
+                "level": 1,
+                "message": "Sensor scan: 2 connected \u2014 5, 26",
+            },
+        ]
+        response = self.client.post(
+            reverse("api:v1:device-status"),
+            data=payload,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        st = DeviceStatus.objects.filter(device=self.device).latest("time_received")
+        self.assertEqual(
+            st.sensor_list,
+            [
+                {"model_id": 5, "dimension_list": []},
+                {"model_id": 26, "dimension_list": []},
+            ],
+        )
+
+    def test_sensor_scan_battery_pipe_format_serial_optional(self):
+        """Firmware line: Battery: … | sensors (N): … serial=…"""
+        msg = (
+            "[INFO] Sensor scan: Battery: none | sensors (2): "
+            "5 serial=n/a; 26 serial=2EBE26EBF3E66049"
+        )
+        payload = self._status_payload()
+        payload["status_list"] = [
+            {"time": "2025-01-07T12:25:00Z", "level": 1, "message": msg},
+        ]
+        response = self.client.post(
+            reverse("api:v1:device-status"),
+            data=payload,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        st = DeviceStatus.objects.filter(device=self.device).latest("time_received")
+        self.assertEqual(
+            st.sensor_list,
+            [
+                {"model_id": 5, "dimension_list": []},
+                {
+                    "model_id": 26,
+                    "dimension_list": [],
+                    "serial": "2EBE26EBF3E66049",
+                },
+            ],
+        )
 
 
 class DeviceDataEndpointTest(TestCase):

--- a/app/api/views/devices.py
+++ b/app/api/views/devices.py
@@ -17,6 +17,7 @@ from drf_spectacular.types import OpenApiTypes
 from django.contrib.gis.geos import Point
 
 from devices.models import Device, DeviceLogs, Measurement, Values
+from devices.sensor_scan import parse_sensor_scan, sensor_list_from_model_ids
 from main.util import get_or_create_station
 from api.models import Location, MobilityMode
 from workshops.models import Participant, Workshop
@@ -120,7 +121,7 @@ class CreateDeviceStatusAPIView(APIView):
             logger.warning("Device status 400: missing device or status_list. Request body: %s", request.data)
             raise ValidationError("Both 'device' and 'status_list' are required.")
 
-        device = get_or_create_station(station_info=device_data)
+        device, station_status = get_or_create_station(station_info=device_data)
 
         if device.api_key != device_data.get("apikey"):
             logger.warning("Device status 400: wrong API key. Request body: %s", request.data)
@@ -141,6 +142,22 @@ class CreateDeviceStatusAPIView(APIView):
                         level=status_data.get("level", 1),
                         message=status_data.get("message", ""),
                     )
+
+                scan_parse = None
+                for status_data in status_list:
+                    if status_data.get("level", 1) != 1:
+                        continue
+                    msg = status_data.get("message", "") or ""
+                    parsed = parse_sensor_scan(msg)
+                    if parsed is not None:
+                        scan_parse = parsed
+                if scan_parse is not None:
+                    station_status.sensor_list = sensor_list_from_model_ids(
+                        scan_parse.model_ids,
+                        previous=station_status.sensor_list,
+                        serial_by_model=scan_parse.serial_by_model,
+                    )
+                    station_status.save(update_fields=["sensor_list"])
 
             device.refresh_from_db()
             payload = {
@@ -216,7 +233,7 @@ class CreateDeviceDataAPIView(APIView):
                 "model": device_data.get("model"),
                 "apikey": device_data.get("apikey"),
             }
-            device = get_or_create_station(station_info=device_info)
+            device, _ = get_or_create_station(station_info=device_info)
 
             if device.api_key != device_data.get("apikey"):
                 raise ValidationError("Wrong API Key")

--- a/app/devices/sensor_scan.py
+++ b/app/devices/sensor_scan.py
@@ -1,0 +1,174 @@
+"""Parse firmware Sensor scan INFO lines into DeviceStatus.sensor_list entries."""
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger("myapp")
+
+# Legacy: "... N connected — 1, 2, 3"
+_SENSOR_SCAN_CONNECTED_RE = re.compile(
+    r"(?:\[(?i:info)\]\s*)?"
+    r"Sensor\s+scan:\s*(\d+)\s+connected\s*[—–-]\s*([\d,\s]+)",
+    re.IGNORECASE,
+)
+
+# Extended: "... Battery: ... | sensors (N): id serial=value; ..."
+_SENSOR_SCAN_BATTERY_RE = re.compile(
+    r"(?:\[(?i:info)\]\s*)?"
+    r"Sensor\s+scan:\s*Battery\s*:\s*(?P<battery>.+?)"
+    r"\|\s*sensors\s*\(\s*(?P<count>\d+)\s*\)"
+    r"\s*:\s*(?P<sensors>.+)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+_SENSOR_LINE_RE = re.compile(
+    r"^(\d+)\s+serial\s*=\s*(.*)$",
+    re.IGNORECASE,
+)
+
+
+_SERIAL_PLACEHOLDER = frozenset({"", "n/a", "none", "nan"})
+
+
+@dataclass(frozen=True)
+class SensorScanParsed:
+    """Result of parsing a Sensor scan log line."""
+
+    model_ids: list[int]
+    # None = legacy comma list format (omit serial keys in sensor_list entries).
+    serial_by_model: dict[int, str | None] | None
+
+
+def parse_sensor_scan(message: str) -> SensorScanParsed | None:
+    """
+    Recognize either::
+
+        [INFO] Sensor scan: N connected — 5, 26
+        [INFO] Sensor scan: Battery: none | sensors (2): 5 serial=n/a; 26 serial=HEX…
+    """
+    if not message:
+        return None
+    text = message.strip()
+    ids, serial_map = _try_parse_battery_pipe_format(text)
+    if ids is not None:
+        return SensorScanParsed(model_ids=ids, serial_by_model=serial_map)
+
+    ids = _parse_connected_separator_format(text)
+    if ids is not None:
+        return SensorScanParsed(model_ids=ids, serial_by_model=None)
+    return None
+
+
+def parse_sensor_scan_model_ids(message: str) -> list[int] | None:
+    """Backward-compatible helper: model IDs only, or None if no Sensor scan."""
+    parsed = parse_sensor_scan(message)
+    return parsed.model_ids if parsed else None
+
+
+def _try_parse_battery_pipe_format(text: str) -> tuple[list[int], dict[int, str | None]] | tuple[None, None]:
+    m = _SENSOR_SCAN_BATTERY_RE.search(text)
+    if not m:
+        return None, None
+    declared = int(m.group("count"))
+    raw_block = (m.group("sensors") or "").strip()
+
+    ids: list[int] = []
+    serial_by_model: dict[int, str | None] = {}
+    seen: set[int] = set()
+
+    for segment in re.split(r"\s*;\s*", raw_block):
+        seg = segment.strip()
+        if not seg:
+            continue
+        lm = _SENSOR_LINE_RE.match(seg)
+        if not lm:
+            logger.warning("Sensor scan: unrecognized sensor segment %r", seg)
+            continue
+        mid = int(lm.group(1))
+        raw_serial = lm.group(2).strip() if lm.group(2) is not None else ""
+        if raw_serial.lower() in _SERIAL_PLACEHOLDER:
+            serial_val: str | None = None
+        else:
+            serial_val = raw_serial
+        serial_by_model[mid] = serial_val
+        if mid not in seen:
+            seen.add(mid)
+            ids.append(mid)
+
+    if declared != len(ids):
+        logger.warning(
+            "Sensor scan declared sensors(%s) but parsed %s entries",
+            declared,
+            len(ids),
+        )
+
+    return ids, serial_by_model
+
+
+def _parse_connected_separator_format(text: str) -> list[int] | None:
+    m = _SENSOR_SCAN_CONNECTED_RE.search(text)
+    if not m:
+        return None
+    declared_count = int(m.group(1))
+    raw_ids = m.group(2)
+    ids: list[int] = []
+    seen: set[int] = set()
+    for part in raw_ids.split(","):
+        token = part.strip()
+        if not token:
+            continue
+        mid = int(token)
+        if mid not in seen:
+            seen.add(mid)
+            ids.append(mid)
+    if declared_count != len(ids):
+        logger.warning(
+            "Sensor scan declared %s connected sensors but parsed %s model_ids from message",
+            declared_count,
+            len(ids),
+        )
+    return ids
+
+
+def sensor_list_from_model_ids(
+    model_ids: list[int],
+    *,
+    serial_by_model: dict[int, str | None] | None = None,
+    previous: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """
+    Build sensor_list payloads: one entry per unique model_id in order.
+
+    Copies dimension_list from *previous* when the same model_id exists.
+    Adds *serial* when *serial_by_model* is provided and the value is non-placeholder.
+    """
+    dim_by_model: dict[int, list[Any]] = {}
+    if previous:
+        for entry in previous:
+            try:
+                mid = int(entry["model_id"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            dims = entry.get("dimension_list")
+            if isinstance(dims, list):
+                dim_by_model[mid] = list(dims)
+            else:
+                dim_by_model[mid] = []
+
+    out: list[dict[str, Any]] = []
+    seen: set[int] = set()
+    for mid in model_ids:
+        if mid in seen:
+            continue
+        seen.add(mid)
+        prev_dims = dim_by_model.get(mid, [])
+        entry: dict[str, Any] = {"model_id": mid, "dimension_list": list(prev_dims)}
+        if serial_by_model is not None and mid in serial_by_model:
+            s = serial_by_model[mid]
+            if s is not None and str(s).strip():
+                entry["serial"] = str(s).strip()
+        out.append(entry)
+    return out

--- a/app/main/util.py
+++ b/app/main/util.py
@@ -44,8 +44,7 @@ def get_or_create_station(station_info: dict):
 
     creates a station_status entry with the information in station_info
 
-    return: Device if there exists a Device where Device.id = station_info['device']
-            else new device is created
+    return: (Device, DeviceStatus) — the device row and the newly created status row.
     '''
     station, created = Device.objects.get_or_create(
         id = station_info['device']
@@ -71,7 +70,7 @@ def get_or_create_station(station_info: dict):
     station.save()
     station_status.save()
 
-    return station
+    return station, station_status
 
 
 def room_calculate_current_values(room):


### PR DESCRIPTION
- Introduced a new module for parsing sensor scan messages, supporting both legacy and extended formats.
- Enhanced the CreateDeviceStatusAPIView to update the sensor list based on parsed scan data.
- Updated get_or_create_station utility to return both Device and DeviceStatus.
- Added comprehensive tests for sensor scan handling in test_devices.py.