### PR TITLE
Add new sensor models and update existing sensor definitions

### DIFF
--- a/app/main/enums.py
+++ b/app/main/enums.py
@@ -46,6 +46,8 @@ class SensorModel():
     SEN66 = 23
     MLX90640 = 24
     TSL2591 = 25
+    SEN63C = 26
+    SEN62 = 27
 
     _names = {
         SEN5X: "SEN5X",
@@ -73,6 +75,8 @@ class SensorModel():
         SEN66: "SEN66",
         MLX90640: "MLX90640",
         TSL2591: "TSL_2591",
+        SEN63C: "SEN63C",
+        SEN62: "SEN62",
     }
 
     _manufacturer = {
@@ -94,13 +98,11 @@ class SensorModel():
         PMS5003: "Plantower",
         PMS7003: "Plantower",
         VIRTUAL_SENSOR: "Luftdaten.at",
-        LTR390: "Lite-On",
-        BMP388: "Bosch Sensortec",
-        BMP390: "Bosch Sensortec",
-        LSM6DS: "STMicroelectronics",
         SEN66: "Sensirion",
         MLX90640: "Mouser Electronics",
-        TSL2591: "Berry Base",
+        TSL2591: "ams OSRAM",
+        SEN63C: "Sensirion",
+        SEN62: "Sensirion",
     }
 
     _pins = {
@@ -117,6 +119,9 @@ class SensorModel():
         SHT35: 7,
         SHT4X: 7,
         SEN5X: 16,
+        SEN66: 16,
+        SEN63C: 17,
+        SEN62: 18,
     }
 
     @classmethod
@@ -358,6 +363,10 @@ class AirstationConfigFlags:
     MQTT_DISCOVERY_PREFIX = 15
     MQTT_DEVICE_NAME = 16
     MQTT_CERTIFICATE_PATH = 17
+    # IANA timezone name (e.g. ``Europe/Vienna``); Air Station ``0x06`` TLV only — not used with Cube ``0x07``
+    TZ = 18
+    LOG_LEVEL = 19
+    API_KEY = 20
 
 
 class AirStationMeasurementInterval:

--- a/app/templates/_base.html
+++ b/app/templates/_base.html
@@ -163,6 +163,11 @@
         static BMP388 = 20;
         static BMP390 = 21;
         static LSM6DS = 22;
+        static SEN66 = 23;
+        static MLX90640 = 24;
+        static TSL2591 = 25;
+        static SEN63C = 26;
+        static SEN62 = 27;
 
         static names = {
             1: "SEN5X",
@@ -186,7 +191,12 @@
             19: "LTR390",
             20: "BMP388",
             21: "BMP390",
-            22: "lsm6ds"
+            22: "lsm6ds",
+            23: "SEN66",
+            24: "MLX90640",
+            25: "TSL_2591",
+            26: "SEN63C",
+            27: "SEN62"
         };
 
         static getSensorName(sensorModel) {
@@ -225,6 +235,11 @@
         static GYRO_X = 28;
         static GYRO_Y = 29;
         static GYRO_Z = 30;
+        static THERMAL_ARRAY = 31;
+        static VISIBLE = 32;
+        static INFRARED = 33;
+        static FULL_SPECTRUM = 34;
+        static RAW_LUMINOSITY = 35;
 
         static units = {
             1: "µg/m³",
@@ -253,7 +268,12 @@
             29: "radians/s",
             30: "radians/s",
             23: "UV Index",
-            24: "lx"
+            24: "lx",
+            31: "°C",
+            32: "count",
+            33: "count",
+            34: "count",
+            35: "count"
         };
 
         static names = {
@@ -285,7 +305,12 @@
             29: "gyro Y",
             30: "gyro Z",
             23: "UV Index",
-            24: "Lux"
+            24: "Lux",
+            31: "Thermal Image",
+            32: "Visible",
+            33: "Infrared",
+            34: "Full spectrum",
+            35: "Raw luminosity"
         };
 
         static sensorCommunityNames = {


### PR DESCRIPTION
- Added SEN63C and SEN62 sensor models to the SensorModel class.
- Updated manufacturer information for TSL2591, SEN63C, and SEN62.
- Enhanced the mapping of sensor models and names in the JavaScript template.
- Introduced new constants for additional sensor data in the base HTML template.