### PR TITLE
Update GitHub Actions workflow to trigger on published releases

### DIFF
--- a/.github/workflows/build-docker-image-production.yml
+++ b/.github/workflows/build-docker-image-production.yml
@@ -2,7 +2,10 @@ name: Build and Publish Docker Image for Production
 
 on:
   release:
-    types: [created]
+    # Use `published` so the workflow runs when a release becomes public (incl.
+    # "Publish release" after a draft). `created` alone often does not fire in
+    # that flow — see GitHub docs: github.com/actions/using-workflows/events-that-trigger-workflows#release
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
- Changed the release trigger type from `created` to `published` to ensure the workflow runs when a release becomes public, including after a draft is published. This adjustment aligns with GitHub documentation for workflow events.