### PR TITLE
Add overview summary for air stations in the dashboard

### DIFF
--- a/app/devices/tests.py
+++ b/app/devices/tests.py
@@ -189,6 +189,49 @@ class AirStationsOverviewTests(TestCase):
         self.assertContains(response, 'Device online')
         self.assertContains(response, '2.0')
 
+    def test_overview_summary_context(self):
+        """Summary cards: 24h status, firmware and sensor breakdowns."""
+        measured_time = timezone.now()
+        with_log = Device.objects.create(
+            id='111111111111111',
+            model=LdProduct.AIR_STATION,
+            auto_number=1,
+            firmware='1.0',
+            last_update=measured_time,
+        )
+        DeviceLogs.objects.create(
+            device=with_log,
+            timestamp=timezone.now(),
+            level=1,
+            message='online',
+        )
+        Measurement.objects.create(
+            device=with_log,
+            time_measured=measured_time,
+            sensor_model=1,
+        )
+        Device.objects.create(
+            id='222222222222222',
+            model=LdProduct.AIR_STATION,
+            auto_number=2,
+            firmware='2.0',
+        )
+
+        self.client.login(username='admin', password='testpass123')
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        summary = response.context['overview_summary']
+        self.assertEqual(summary['total_count'], 2)
+        self.assertEqual(summary['status_last_24h_count'], 1)
+        firmware_dict = dict(summary['firmware_counts'])
+        self.assertEqual(firmware_dict['1.0'], 1)
+        self.assertEqual(firmware_dict['2.0'], 1)
+        sensor_dict = dict(summary['sensor_counts'])
+        self.assertEqual(sensor_dict['SEN5X'], 1)
+        self.assertContains(response, 'Status (24h)')
+        self.assertContains(response, 'By firmware')
+        self.assertContains(response, 'By sensor')
+
     def test_sensors_column_from_measurements_at_last_update(self):
         """Sensors column lists sensor names (not dimensions) from measurements at device.last_update."""
         measured_time = timezone.now()

--- a/app/devices/views.py
+++ b/app/devices/views.py
@@ -2,7 +2,8 @@ import io
 import json
 import logging
 import zipfile
-from collections import defaultdict
+from collections import Counter, defaultdict
+from datetime import timedelta
 import csv
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
@@ -38,9 +39,9 @@ from django.db.models.functions import Length
 logger = logging.getLogger('myapp')
 
 
-def air_station_sensors_display(device):
+def air_station_sensor_names(device):
     """
-    Sensor names only for the air stations table (no dimensions).
+    Sensor names for an air station (no dimensions).
     Same sources as device detail: measurements at last_update, else latest status sensor_list.
     """
     names = set()
@@ -56,9 +57,44 @@ def air_station_sensors_display(device):
         if status and status.sensor_list:
             for data in status.sensor_list:
                 names.add(SensorModel.get_sensor_name(data["model_id"]))
+    return sorted(names)
+
+
+def air_station_sensors_display(device):
+    names = air_station_sensor_names(device)
     if not names:
         return ""
-    return ", ".join(sorted(names))
+    return ", ".join(names)
+
+
+def air_station_overview_summaries(air_stations, sensor_names_by_device=None):
+    """Aggregate counts for the air stations overview summary cards."""
+    cutoff = timezone.now() - timedelta(hours=24)
+    status_last_24h_count = 0
+    firmware_counter = Counter()
+    sensor_counter = Counter()
+
+    for device in air_stations:
+        if device.last_log_time and device.last_log_time >= cutoff:
+            status_last_24h_count += 1
+        firmware_counter[device.firmware if device.firmware else "N/A"] += 1
+        names = (
+            sensor_names_by_device.get(device.pk)
+            if sensor_names_by_device is not None
+            else air_station_sensor_names(device)
+        )
+        for name in names:
+            sensor_counter[name] += 1
+
+    firmware_counts = sorted(firmware_counter.items(), key=lambda x: x[0].lower())
+    sensor_counts = sorted(sensor_counter.items(), key=lambda x: (-x[1], x[0].lower()))
+
+    return {
+        "total_count": len(air_stations),
+        "status_last_24h_count": status_last_24h_count,
+        "firmware_counts": firmware_counts,
+        "sensor_counts": sensor_counts,
+    }
 
 
 class DeviceListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
@@ -107,8 +143,15 @@ class AirStationsOverviewView(LoginRequiredMixin, UserPassesTestMixin, ListView)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        for device in context['air_stations']:
-            device.sensors_display = air_station_sensors_display(device)
+        air_stations = context['air_stations']
+        sensor_names_by_device = {}
+        for device in air_stations:
+            names = air_station_sensor_names(device)
+            sensor_names_by_device[device.pk] = names
+            device.sensors_display = ", ".join(names) if names else ""
+        context['overview_summary'] = air_station_overview_summaries(
+            air_stations, sensor_names_by_device=sensor_names_by_device
+        )
         return context
 
 

--- a/app/templates/devices/air_stations_overview.html
+++ b/app/templates/devices/air_stations_overview.html
@@ -28,8 +28,59 @@
         </div>
         {% endif %}
     </div>
-    
+
     {% if air_stations %}
+        <div class="row mb-4">
+            <div class="col-md-4 col-sm-6 mb-3">
+                <div class="card text-center shadow-sm h-100">
+                    <div class="card-body">
+                        <h5 class="card-title mb-3">{% trans "Status (24h)" %}</h5>
+                        <p class="display-6 mb-1">
+                            {{ overview_summary.status_last_24h_count }} / {{ overview_summary.total_count }}
+                        </p>
+                        <p class="text-muted small mb-0">{% trans "with status in last 24 hours" %}</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-4 col-sm-6 mb-3">
+                <div class="card shadow-sm h-100">
+                    <div class="card-body">
+                        <h5 class="card-title mb-3">{% trans "By firmware" %}</h5>
+                        {% if overview_summary.firmware_counts %}
+                            <ul class="list-unstyled mb-0 small" style="max-height: 12rem; overflow-y: auto;">
+                                {% for label, count in overview_summary.firmware_counts %}
+                                    <li class="d-flex justify-content-between gap-2">
+                                        <span class="text-break">{{ label }}</span>
+                                        <span class="fw-semibold">{{ count }}</span>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        {% else %}
+                            <p class="text-muted mb-0">{% trans "No data" %}</p>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-4 col-sm-12 mb-3">
+                <div class="card shadow-sm h-100">
+                    <div class="card-body">
+                        <h5 class="card-title mb-3">{% trans "By sensor" %}</h5>
+                        {% if overview_summary.sensor_counts %}
+                            <ul class="list-unstyled mb-0 small" style="max-height: 12rem; overflow-y: auto;">
+                                {% for name, count in overview_summary.sensor_counts %}
+                                    <li class="d-flex justify-content-between gap-2">
+                                        <span class="text-break">{{ name }}</span>
+                                        <span class="fw-semibold">{{ count }}</span>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        {% else %}
+                            <p class="text-muted mb-0">{% trans "No data" %}</p>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
         <div
             id="air-station-firmware-filters"
             class="d-flex flex-wrap align-items-center gap-2 mb-3"


### PR DESCRIPTION
- Implemented a new context for air station overview summaries, including total device count, status in the last 24 hours, and breakdowns by firmware and sensor.
- Updated the air stations overview template to display summary cards for status, firmware, and sensor counts.
- Refactored sensor name retrieval functions for clarity and efficiency in the context of the overview.