### PR TITLE
Add BMP581 and SHTC3 sensor models to enums and template

### DIFF
--- a/app/main/enums.py
+++ b/app/main/enums.py
@@ -48,6 +48,8 @@ class SensorModel():
     TSL2591 = 25
     SEN63C = 26
     SEN62 = 27
+    BMP581 = 28
+    SHTC3 = 29
 
     _names = {
         SEN5X: "SEN5X",
@@ -77,6 +79,8 @@ class SensorModel():
         TSL2591: "TSL_2591",
         SEN63C: "SEN63C",
         SEN62: "SEN62",
+        BMP581: "BMP581",
+        SHTC3: "SHTC3",
     }
 
     _manufacturer = {
@@ -103,6 +107,8 @@ class SensorModel():
         TSL2591: "ams OSRAM",
         SEN63C: "Sensirion",
         SEN62: "Sensirion",
+        BMP581: "Bosch Sensortec",
+        SHTC3: "Sensirion",
     }
 
     _pins = {
@@ -113,11 +119,13 @@ class SensorModel():
         BME280: 11,
         BME680: 11,
         BMP280: 3,
+        BMP581: 3,
         DHT22: 7,
         SHT30: 7,
         SHT31: 7,
         SHT35: 7,
         SHT4X: 7,
+        SHTC3: 7,
         SEN5X: 16,
         SEN66: 16,
         SEN63C: 17,

--- a/app/templates/_base.html
+++ b/app/templates/_base.html
@@ -168,6 +168,8 @@
         static TSL2591 = 25;
         static SEN63C = 26;
         static SEN62 = 27;
+        static BMP581 = 28;
+        static SHTC3 = 29;
 
         static names = {
             1: "SEN5X",
@@ -196,7 +198,9 @@
             24: "MLX90640",
             25: "TSL_2591",
             26: "SEN63C",
-            27: "SEN62"
+            27: "SEN62",
+            28: "BMP581",
+            29: "SHTC3"
         };
 
         static getSensorName(sensorModel) {


### PR DESCRIPTION
- Introduced BMP581 and SHTC3 sensor models in the SensorModel class.
- Updated corresponding names and manufacturers for the new sensors.
- Modified the base HTML template to include new sensor constants and names.