### PR TITLE
Add station name endpoint and serializer

### DIFF
--- a/app/api/serializers/__init__.py
+++ b/app/api/serializers/__init__.py
@@ -15,6 +15,7 @@ from .devices import (
     DeviceStatusLogSerializer,
     SensorDataSerializer,
     SensorSerializer,
+    StationNameSerializer,
     WorkshopContextSerializer,
 )
 from .workshops import (
@@ -37,6 +38,7 @@ __all__ = [
     "DeviceStatusLogSerializer",
     "SensorDataSerializer",
     "SensorSerializer",
+    "StationNameSerializer",
     "WorkshopContextSerializer",
     "WorkshopSerializer",
     "WorkshopSpotPkSerializer",

--- a/app/api/serializers/devices.py
+++ b/app/api/serializers/devices.py
@@ -129,3 +129,10 @@ class DeviceStatusRequestSerializer(serializers.Serializer):
 
     device = DeviceInfoSerializer()
     status_list = serializers.ListField(child=DeviceStatusLogSerializer())
+
+
+class StationNameSerializer(serializers.Serializer):
+    """Response for GET /v1/stations/name/."""
+
+    device = serializers.CharField()
+    device_name = serializers.CharField()

--- a/app/api/tests/test_stations.py
+++ b/app/api/tests/test_stations.py
@@ -1,0 +1,54 @@
+"""Tests for station API endpoints."""
+from django.urls import reverse
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from devices.models import Device
+from main.enums import LdProduct
+
+
+class StationNameEndpointTest(TestCase):
+    """GET /api/v1/stations/name/ - resolve device name by id."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.url = reverse("api:v1:station-name")
+        self.device = Device.objects.create(
+            id="D83BDA6E37DDAAA",
+            device_name="Air Cube 0042",
+            model=LdProduct.AIR_CUBE,
+            auto_number=42,
+        )
+        self.air_station = Device.objects.create(
+            id="123456789012345",
+            model=LdProduct.AIR_STATION,
+            auto_number=7,
+        )
+
+    def test_returns_device_name_for_full_id(self):
+        response = self.client.get(self.url, {"device": self.device.id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["device"], self.device.id)
+        self.assertEqual(response.data["device_name"], "Air Cube 0042")
+
+    def test_missing_device_param_returns_400(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("device", response.data)
+
+    def test_unknown_device_returns_404(self):
+        response = self.client.get(self.url, {"device": "UNKNOWN000000000"})
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_air_station_short_auto_number(self):
+        response = self.client.get(self.url, {"device": "7"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["device"], self.air_station.id)
+        self.assertEqual(response.data["device_name"], "Station 7")
+
+    def test_fallback_to_device_id_when_name_empty(self):
+        bare = Device.objects.create(id="AAAAAAAAAAAAAAA")
+        response = self.client.get(self.url, {"device": bare.id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["device_name"], bare.id)

--- a/app/api/urls/v1.py
+++ b/app/api/urls/v1.py
@@ -14,6 +14,7 @@ from api.views import (
     CreateWorkshopSpotAPIView,
     DeleteWorkshopSpotAPIView,
     GetWorkshopSpotsAPIView,
+    StationNameView,
     WorkshopAirQualityDataView,
     WorkshopDetailView,
 )
@@ -31,6 +32,9 @@ urlpatterns = [
     # Devices (status and data)
     path("devices/status/", CreateDeviceStatusAPIView.as_view(), name="device-status"),
     path("devices/data/", CreateDeviceDataAPIView.as_view(), name="device-data"),
+
+    # Stations
+    path("stations/name/", StationNameView.as_view(), name="station-name"),
 
     # Workshops
     path("workshops/data/add/", AirQualityDataAddView.as_view(), name="workshop-data-add"),

--- a/app/api/views/__init__.py
+++ b/app/api/views/__init__.py
@@ -3,6 +3,7 @@ from .devices import (
     CreateDeviceDataAPIView,
     CreateDeviceStatusAPIView,
     DeviceDetailView,
+    StationNameView,
 )
 from .workshops import (
     AirQualityDataAddView,
@@ -27,6 +28,7 @@ __all__ = [
     "DeleteWorkshopSpotAPIView",
     "DeviceDetailView",
     "GetWorkshopSpotsAPIView",
+    "StationNameView",
     "WorkshopAirQualityDataView",
     "WorkshopDetailView",
 ]

--- a/app/api/views/devices.py
+++ b/app/api/views/devices.py
@@ -23,7 +23,14 @@ from main.util import get_or_create_station
 from api.models import Location, MobilityMode
 from workshops.models import Participant, Workshop
 
-from api.serializers import DeviceSerializer, DeviceDataSerializer, DeviceStatusRequestSerializer
+from stations.station_url import resolve_station_from_pk
+
+from api.serializers import (
+    DeviceSerializer,
+    DeviceDataSerializer,
+    DeviceStatusRequestSerializer,
+    StationNameSerializer,
+)
 
 logger = logging.getLogger("myapp")
 
@@ -121,6 +128,46 @@ def _latest_status_list_level(status_list):
 class DeviceDetailView(RetrieveAPIView):
     queryset = Device.objects.all()
     serializer_class = DeviceSerializer
+
+
+@extend_schema(
+    tags=["stations"],
+    summary="Get device name by station id",
+    description=(
+        "Returns the human-readable device name for a station/device id. "
+        "Accepts the full device primary key or a short Air Station auto-number."
+    ),
+    parameters=[
+        OpenApiParameter(
+            name="device",
+            type=OpenApiTypes.STR,
+            location=OpenApiParameter.QUERY,
+            description="Device id (station hardware id or Air Station auto-number)",
+            required=True,
+            examples=[OpenApiExample("Example device", value="D83BDA6E37DDAAA")],
+        )
+    ],
+    responses={
+        200: StationNameSerializer,
+        400: {"description": "Missing or invalid query parameter"},
+        404: {"description": "Device not found"},
+    },
+)
+class StationNameView(APIView):
+    def get(self, request):
+        device_id = (request.query_params.get("device") or "").strip()
+        if not device_id:
+            raise ValidationError({"device": "Query parameter 'device' is required."})
+        resolution = resolve_station_from_pk(device_id)
+        if resolution.device is None:
+            return Response({"detail": "Device not found."}, status=status.HTTP_404_NOT_FOUND)
+        dev = resolution.device
+        return Response(
+            {
+                "device": dev.id,
+                "device_name": dev.device_name or dev.id,
+            }
+        )
 
 
 @extend_schema(


### PR DESCRIPTION
- Introduced StationNameSerializer for handling device name responses.
- Implemented StationNameView to resolve device names by ID or short auto-number.
- Added tests for the new station name API endpoint to ensure correct functionality and error handling.
- Updated API URLs and serializers to include the new station name feature.